### PR TITLE
Add developer documentation for Abilities API (#5)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+Add this near the top after the main heading:
+
+````md
+## Quick Start
+
+```php
+// Register a custom ability
+register_ability(
+    'my_plugin_edit_data',
+    array(
+        'label'       => __( 'Edit plugin data', 'my-plugin' ),
+        'description' => __( 'Allows editing of My Plugin data.', 'my-plugin' ),
+    )
+);
+
+// Check if a user has the ability
+if ( user_can( get_current_user_id(), 'my_plugin_edit_data' ) ) {
+    // Perform restricted action
+}
+```
+````

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,28 @@
+# Getting Started
+
+## Prerequisites
+- WordPress development environment (e.g., LocalWP, Docker, XAMPP)
+- PHP 7.4+ (recommended PHP 8.0+)
+- Git for version control
+- Composer (optional, if the package will be installed via Composer in the future)
+
+## Steps
+
+1. **Clone or Install**
+   ```bash
+   git clone https://github.com/YOUR-USERNAME/abilities-api.git
+   cd abilities-api
+
+2. **Activate in WordPress**
+
+Place the abilities-api code inside your wp-content/plugins folder.
+
+Activate it from the WordPress admin.
+
+3. **Verify**
+
+Check that the Abilities API functions (e.g., register_ability()) are available.
+
+Optionally, use WP-CLI or REST API to confirm abilities can be listed.
+
+Next: Registering Abilities

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,0 +1,19 @@
+# Introduction to the Abilities API
+
+The Abilities API is a proposed WordPress feature for defining and checking custom permissions (called "abilities") in a standardized way.
+
+It allows plugins and themes to:
+
+- Register new abilities
+- Assign abilities to specific roles or users
+- Check if a user has a specific ability before performing an action
+- Expose abilities through the REST API for integration with external systems
+
+This documentation will guide you through getting started, registering abilities, using abilities in your code, and interacting with the REST API.
+
+---
+**Related Docs:**  
+- [Getting Started](./getting-started.md)  
+- [Registering Abilities](./registering-abilities.md)  
+- [Using Abilities](./using-abilities.md)  
+- [REST API Endpoints](./rest-api-endpoints.md)

--- a/docs/registering-abilities.md
+++ b/docs/registering-abilities.md
@@ -1,0 +1,28 @@
+# Registering Abilities
+
+The Abilities API allows you to define new permissions in WordPress.
+
+## Basic Example
+
+```php
+
+register_ability(
+    'my_plugin_edit_data',
+    array(
+        'label'       => __( 'Edit My Plugin Data', 'my-plugin' ),
+        'description' => __( 'Allows editing of data in My Plugin.', 'my-plugin' ),
+    )
+);
+```
+
+Next Step : **Parameters**
+
+Name (string) – Unique identifier for the ability.
+
+Args (array) – Associative array with:
+
+label (string) – Human-readable name.
+
+description (string) – Short explanation.
+
+Tip: Always prefix your ability names to avoid conflicts.

--- a/docs/rest-api-endpoints.md
+++ b/docs/rest-api-endpoints.md
@@ -1,0 +1,29 @@
+# REST API Endpoints
+
+The Abilities API exposes REST routes for managing abilities.
+
+## List Abilities
+```bash
+GET /wp-json/abilities/v1/list  
+
+Response:
+
+[
+  {
+    "name": "my_plugin_edit_data",
+    "label": "Edit My Plugin Data",
+    "description": "Allows editing of data in My Plugin."
+  }
+]
+
+
+ 2. **Register Ability** :
+
+POST /wp-json/abilities/v1/register
+Content-Type: application/json
+
+{
+  "name": "my_plugin_view_stats",
+  "label": "View Plugin Stats",
+  "description": "Allows viewing analytics data."
+}

--- a/docs/using-abilities.md
+++ b/docs/using-abilities.md
@@ -1,0 +1,28 @@
+# Using Abilities
+
+After registering abilities, you can check them in your code to control access.
+
+## Check if Current User Has Ability
+
+```php
+
+if ( user_can( get_current_user_id(), 'my_plugin_edit_data' ) ) {
+    // Perform action
+} else {
+    wp_die( __( 'You do not have permission to do this.', 'my-plugin' ) );
+}
+```
+
+```
+
+```Abilities can be assigned via:
+
+WordPress role management functions
+
+Custom role editing plugins
+
+Direct database queries (not recommended unless necessary)
+
+Removing Abilities :
+
+remove_ability( 'my_plugin_edit_data' );


### PR DESCRIPTION
 “Fixes #5” so GitHub links the PR to the issue.

This PR adds developer documentation for the Abilities API.

Changes include:
- New `docs/` folder with:
  - intro.md
  - getting-started.md
  - registering-abilities.md
  - using-abilities.md
  - rest-api-endpoints.md
- Updated README with Quick Start example and links to docs.