### PR TITLE
chore: php remediations

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -58,7 +58,10 @@
 		<!-- Deprecated: @todo remove in PHPCS 4.0 -->
 		<exclude name="WordPressVIPMinimum.JS" />
 	</rule>
-	<rule ref="WordPress-Extra" />
+	<rule ref="WordPress-Extra">
+		<!-- Needed to typehint, see: https://github.com/WordPress/WordPress-Coding-Standards/issues/403 -->
+		<exclude name="Generic.Commenting.DocComment.MissingShort" />
+	</rule>
 
 	<!--
 		Load PHPCompatibility & PHPCompatibilityWP
@@ -70,7 +73,8 @@
 		Checks from PCP
 		@see https://github.com/wordpress/plugin-check
 	-->
-	<rule ref="./vendor/wpackagist-plugin/plugin-check/vendor/plugin-check/phpcs-sniffs/PluginCheck/ruleset.xml" />
+	<rule
+		ref="./vendor/wpackagist-plugin/plugin-check/vendor/plugin-check/phpcs-sniffs/PluginCheck/ruleset.xml" />
 	<rule ref="./vendor/wpackagist-plugin/plugin-check/phpcs-rulesets/plugin-check.ruleset.xml" />
 
 	<!-- Check for superfluous whitespace - These get suppressed in VIP-GO.-->
@@ -86,13 +90,6 @@
 	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing">
 		<properties>
 			<property name="blank_line_check" value="true" />
-		</properties>
-	</rule>
-
-	<!-- Allow inheritDoc comments -->
-	<rule ref="Squiz.Commenting.FunctionComment">
-		<properties>
-			<property name="skipIfInheritdoc" value="true" />
 		</properties>
 	</rule>
 
@@ -164,6 +161,7 @@
 	<rule ref="SlevomatCodingStandard.PHP.UselessParentheses" />
 	<rule ref="SlevomatCodingStandard.PHP.UselessSemicolon" />
 
+	<rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints" />
 	<rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
 	<rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition" />
 	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
@@ -171,7 +169,8 @@
 			<property name="enableMixedTypeHint" value="false" /><!-- Only available in PHP 8.0+ -->
 			<property name="enableUnionTypeHint" value="false" /><!-- Only available in PHP 8.0+ -->
 			<property name="enableIntersectionTypeHint" value="false" /><!-- Only available in PHP 8.1+ -->
-			<property name="enableStandaloneNullTrueFalseTypeHints" value="false" /><!-- Only available in PHP 8.2+ -->
+			<property name="enableStandaloneNullTrueFalseTypeHints" value="false" /><!-- Only available in
+			PHP 8.2+ -->
 		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
@@ -180,7 +179,8 @@
 			<property name="enableMixedTypeHint" value="false" /><!-- Only available in PHP 8.0+ -->
 			<property name="enableUnionTypeHint" value="false" /><!-- Only available in PHP 8.0+ -->
 			<property name="enableIntersectionTypeHint" value="false" /><!-- Only available in PHP 8.1+ -->
-			<property name="enableStandaloneNullTrueFalseTypeHints" value="false" /><!-- Only available in PHP 8.2+ -->
+			<property name="enableStandaloneNullTrueFalseTypeHints" value="false" /><!-- Only available in
+			PHP 8.2+ -->
 		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
@@ -190,7 +190,8 @@
 			<property name="enableUnionTypeHint" value="false" /><!-- Only available in PHP 8.0+ -->
 			<property name="enableIntersectionTypeHint" value="false" /><!-- Only available in PHP 8.1+ -->
 			<property name="enableNeverTypeHint" value="false" /><!-- Only available in PHP 8.1+ -->
-			<property name="enableStandaloneNullTrueFalseTypeHints" value="false" /><!-- Only available in PHP 8.2+ -->
+			<property name="enableStandaloneNullTrueFalseTypeHints" value="false" /><!-- Only available in
+			PHP 8.2+ -->
 		</properties>
 	</rule>
 
@@ -206,34 +207,6 @@
 	<!--
 		Ignore Rules for Tests
 	-->
-	<!-- Do not require doc-blocks for unit tests -->
-	<rule ref="Squiz.Commenting.FunctionComment.Missing">
-		<exclude-pattern>tests/*</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.FileComment.Missing">
-		<exclude-pattern>tests/*</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.ClassComment.Missing">
-		<exclude-pattern>tests/*</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.ClassComment.SpacingAfter">
-		<exclude-pattern>tests/*</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.FunctionComment.MissingParamTag">
-		<exclude-pattern>tests/*</exclude-pattern>
-	</rule>
-	<rule ref="Generic.Commenting.DocComment.Empty">
-		<exclude-pattern>tests/*</exclude-pattern>
-	</rule>
-	<rule ref="Generic.Commenting.DocComment.MissingShort">
-		<exclude-pattern>tests/*</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.VariableComment.Missing">
-		<exclude-pattern>tests/*</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.FunctionCommentThrowTag.Missing">
-		<exclude-pattern>tests/*</exclude-pattern>
-	</rule>
 	<rule ref="PluginCheck.CodeAnalysis.Offloading.OffloadedContent">
 		<exclude-pattern>/tests/*</exclude-pattern>
 	</rule>
@@ -251,6 +224,7 @@
 		<properties>
 			<property name="prefixes" type="array">
 				<!-- @todo: Should we use a namespace or prefix ? -->
+				<element value="abilities_api" />
 				<element value="WP_Ability" />
 				<element value="WP_Abilities" />
 				<element value="WP_ABILITIES_API" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -59,6 +59,8 @@
 		<exclude name="WordPressVIPMinimum.JS" />
 	</rule>
 	<rule ref="WordPress-Extra">
+		<exclude name="WordPress.WP.I18n.MissingArgDomain" />
+		<exclude name="WordPress.NamingConventions.PrefixAllGlobals" />
 		<!-- Needed to typehint, see: https://github.com/WordPress/WordPress-Coding-Standards/issues/403 -->
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
 	</rule>

--- a/src/abilities-api.php
+++ b/src/abilities-api.php
@@ -1,5 +1,4 @@
-<?php declare( strict_types = 1 );
-
+<?php
 /**
  * Abilities API
  *
@@ -10,6 +9,8 @@
  * @since 0.1.0
  */
 
+declare( strict_types = 1 );
+
 /**
  * Registers a new ability using Abilities API.
  *
@@ -19,13 +20,13 @@
  *
  * @since 0.1.0
  *
- * @param string|WP_Ability $name       The name of the ability, or WP_Ability instance. The name must be a string
- *                                      containing a namespace prefix, i.e. `my-plugin/my-ability`. It can only
- *                                      contain lowercase alphanumeric characters, dashes and the forward slash.
- * @param array             $properties Optional. An associative array of properties for the ability. This should
- *                                      include `label`, `description`, `input_schema`, `output_schema`,
- *                                      `execute_callback`, `permission_callback`, and `meta`.
- * @return ?WP_Ability An instance of registered ability on success, null on failure.
+ * @param string|\WP_Ability  $name       The name of the ability, or WP_Ability instance.
+ *                                        The name must be a string containing a namespace prefix, i.e. `my-plugin/my-ability`. It can only
+ *                                        contain lowercase alphanumeric characters, dashes and the forward slash.
+ * @param array<string,mixed> $properties Optional. An associative array of properties for the ability. This should
+ *                                        include `label`, `description`, `input_schema`, `output_schema`,
+ *                                        `execute_callback`, `permission_callback`, and `meta`.
+ * @return ?\WP_Ability An instance of registered ability on success, null on failure.
  */
 function wp_register_ability( $name, array $properties = array() ): ?WP_Ability {
 	if ( ! did_action( 'abilities_api_init' ) ) {
@@ -35,7 +36,7 @@ function wp_register_ability( $name, array $properties = array() ): ?WP_Ability 
 				/* translators: 1: abilities_api_init, 2: string value of the ability name. */
 				esc_html__( 'Abilities must be registered on the %1$s action. The ability %2$s was not registered.' ),
 				'<code>abilities_api_init</code>',
-				'<code>' . esc_attr( $name ) . '</code>'
+				'<code>' . esc_html( $name ) . '</code>'
 			),
 			'0.1.0'
 		);
@@ -53,7 +54,7 @@ function wp_register_ability( $name, array $properties = array() ): ?WP_Ability 
  * @since 0.1.0
  *
  * @param string $name The name of the registered ability, with its namespace.
- * @return ?WP_Ability The unregistered ability instance on success, null on failure.
+ * @return ?\WP_Ability The unregistered ability instance on success, null on failure.
  */
 function wp_unregister_ability( string $name ): ?WP_Ability {
 	return WP_Abilities_Registry::get_instance()->unregister( $name );
@@ -67,7 +68,7 @@ function wp_unregister_ability( string $name ): ?WP_Ability {
  * @since 0.1.0
  *
  * @param string $name The name of the registered ability, with its namespace.
- * @return ?WP_Ability The registered ability instance, or null if it is not registered.
+ * @return ?\WP_Ability The registered ability instance, or null if it is not registered.
  */
 function wp_get_ability( string $name ): ?WP_Ability {
 	return WP_Abilities_Registry::get_instance()->get_registered( $name );
@@ -80,7 +81,7 @@ function wp_get_ability( string $name ): ?WP_Ability {
  *
  * @since 0.1.0
  *
- * @return WP_Ability[] The array of registered abilities.
+ * @return \WP_Ability[] The array of registered abilities.
  */
 function wp_get_abilities(): array {
 	return WP_Abilities_Registry::get_instance()->get_all_registered();

--- a/src/abilities-api.php
+++ b/src/abilities-api.php
@@ -36,7 +36,7 @@ function wp_register_ability( $name, array $properties = array() ): ?WP_Ability 
 				/* translators: 1: abilities_api_init, 2: string value of the ability name. */
 				esc_html__( 'Abilities must be registered on the %1$s action. The ability %2$s was not registered.' ),
 				'<code>abilities_api_init</code>',
-				'<code>' . esc_html( $name ) . '</code>'
+				'<code>' . esc_html( $name instanceof WP_Ability ? $name->get_name() : $name ) . '</code>'
 			),
 			'0.1.0'
 		);

--- a/src/class-wp-abilities-registry.php
+++ b/src/class-wp-abilities-registry.php
@@ -27,14 +27,6 @@ final class WP_Abilities_Registry {
 	private $registered_abilities = array();
 
 	/**
-	 * Container for the main instance of the class.
-	 *
-	 * @since 0.1.0
-	 * @var ?\WP_Abilities_Registry
-	 */
-	private static $instance = null;
-
-	/**
 	 * Registers a new ability.
 	 *
 	 * Do not use this method directly. Instead, use the `wp_register_ability()` function.

--- a/src/class-wp-abilities-registry.php
+++ b/src/class-wp-abilities-registry.php
@@ -1,5 +1,4 @@
-<?php declare( strict_types = 1 );
-
+<?php
 /**
  * Abilities API
  *
@@ -9,6 +8,8 @@
  * @subpackage Abilities API
  * @since 0.1.0
  */
+
+declare( strict_types = 1 );
 
 /**
  * Manages the registration and lookup of abilities.
@@ -21,7 +22,7 @@ final class WP_Abilities_Registry {
 	 * Holds the registered abilities.
 	 *
 	 * @since 0.1.0
-	 * @var WP_Ability[]
+	 * @var \WP_Ability[]
 	 */
 	private $registered_abilities = array();
 
@@ -29,7 +30,7 @@ final class WP_Abilities_Registry {
 	 * Container for the main instance of the class.
 	 *
 	 * @since 0.1.0
-	 * @var ?WP_Abilities_Registry
+	 * @var ?\WP_Abilities_Registry
 	 */
 	private static $instance = null;
 
@@ -42,13 +43,13 @@ final class WP_Abilities_Registry {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param string|WP_Ability $name       The name of the ability, or WP_Ability instance. The name must be a string
-	 *                                      containing a namespace prefix, i.e. `my-plugin/my-ability`. It can only
-	 *                                      contain lowercase alphanumeric characters, dashes and the forward slash.
-	 * @param array             $properties Optional. An associative array of properties for the ability. This should
-	 *                                      include `label`, `description`, `input_schema`, `output_schema`,
-	 *                                      `execute_callback`, `permission_callback`, and `meta`.
-	 * @return ?WP_Ability The registered ability instance on success, null on failure.
+	 * @param string|\WP_Ability  $name       The name of the ability, or WP_Ability instance. The name must be a string
+	 *                                        containing a namespace prefix, i.e. `my-plugin/my-ability`. It can only
+	 *                                        contain lowercase alphanumeric characters, dashes and the forward slash.
+	 * @param array<string,mixed> $properties Optional. An associative array of properties for the ability. This should
+	 *                                        include `label`, `description`, `input_schema`, `output_schema`,
+	 *                                        `execute_callback`, `permission_callback`, and `meta`.
+	 * @return ?\WP_Ability The registered ability instance on success, null on failure.
 	 */
 	public function register( $name, array $properties = array() ): ?WP_Ability {
 		$ability = null;
@@ -159,6 +160,7 @@ final class WP_Abilities_Registry {
 				'meta'                => $properties['meta'] ?? array(),
 			)
 		);
+
 		$this->registered_abilities[ $name ] = $ability;
 		return $ability;
 	}
@@ -173,9 +175,9 @@ final class WP_Abilities_Registry {
 	 * @since 0.1.0
 	 *
 	 * @param string $name The name of the registered ability, with its namespace.
-	 * @return ?WP_Ability The unregistered ability instance on success, null on failure.
+	 * @return ?\WP_Ability The unregistered ability instance on success, null on failure.
 	 */
-	public function unregister( $name ): ?WP_Ability {
+	public function unregister( string $name ): ?WP_Ability {
 		if ( ! $this->is_registered( $name ) ) {
 			_doing_it_wrong(
 				__METHOD__,
@@ -201,7 +203,7 @@ final class WP_Abilities_Registry {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @return WP_Ability[] The array of registered abilities.
+	 * @return \WP_Ability[] The array of registered abilities.
 	 */
 	public function get_all_registered(): array {
 		return $this->registered_abilities;
@@ -215,7 +217,7 @@ final class WP_Abilities_Registry {
 	 * @param string $name The name of the registered ability, with its namespace.
 	 * @return bool True if the ability is registered, false otherwise.
 	 */
-	public function is_registered( $name ): bool {
+	public function is_registered( string $name ): bool {
 		return isset( $this->registered_abilities[ $name ] );
 	}
 
@@ -229,9 +231,9 @@ final class WP_Abilities_Registry {
 	 * @since 0.1.0
 	 *
 	 * @param string $name The name of the registered ability, with its namespace.
-	 * @return ?WP_Ability The registered ability instance, or null if it is not registered.
+	 * @return ?\WP_Ability The registered ability instance, or null if it is not registered.
 	 */
-	public function get_registered( $name ): ?WP_Ability {
+	public function get_registered( string $name ): ?WP_Ability {
 		if ( ! $this->is_registered( $name ) ) {
 			_doing_it_wrong(
 				__METHOD__,
@@ -251,10 +253,10 @@ final class WP_Abilities_Registry {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @return WP_Abilities_Registry The main registry instance.
+	 * @return \WP_Abilities_Registry The main registry instance.
 	 */
-	public static function get_instance(): WP_Abilities_Registry {
-		/* @var WP_Abilities_Registry $wp_abilities */
+	public static function get_instance(): self {
+		/** @var \WP_Abilities_Registry $wp_abilities */
 		global $wp_abilities;
 
 		if ( empty( $wp_abilities ) ) {
@@ -267,7 +269,7 @@ final class WP_Abilities_Registry {
 			 *
 			 * @since 0.1.0
 			 *
-			 * @param WP_Abilities_Registry $instance Abilities registry object.
+			 * @param \WP_Abilities_Registry $instance Abilities registry object.
 			 */
 			do_action( 'abilities_api_init', $wp_abilities );
 		}
@@ -279,15 +281,12 @@ final class WP_Abilities_Registry {
 	 * Wakeup magic method.
 	 *
 	 * @since 0.1.0
+	 * @throws \UnexpectedValueException If any of the registered abilities is not an instance of WP_Ability.
 	 */
 	public function __wakeup(): void {
-		if ( empty( $this->registered_abilities ) ) {
-			return;
-		}
-
 		foreach ( $this->registered_abilities as $ability ) {
 			if ( ! $ability instanceof WP_Ability ) {
-				throw new UnexpectedValueException();
+				throw new \UnexpectedValueException();
 			}
 		}
 	}

--- a/src/class-wp-ability.php
+++ b/src/class-wp-ability.php
@@ -1,5 +1,4 @@
-<?php declare( strict_types = 1 );
-
+<?php
 /**
  * Abilities API
  *
@@ -9,6 +8,8 @@
  * @subpackage Abilities API
  * @since 0.1.0
  */
+
+declare( strict_types = 1 );
 
 /**
  * Encapsulates the properties and methods related to a specific ability in the registry.
@@ -235,7 +236,7 @@ class WP_Ability {
 	 * @since 0.1.0
 	 *
 	 * @param array $input The input data for the ability.
-	 * @return mixed|WP_Error The result of the ability execution, or WP_Error on failure.
+	 * @return mixed|\WP_Error The result of the ability execution, or WP_Error on failure.
 	 */
 	protected function do_execute( array $input ) {
 		if ( ! is_callable( $this->execute_callback ) ) {
@@ -293,7 +294,7 @@ class WP_Ability {
 	 * @since 0.1.0
 	 *
 	 * @param array $input Optional. The input data for the ability.
-	 * @return mixed|WP_Error The result of the ability execution, or WP_Error on failure.
+	 * @return mixed|\WP_Error The result of the ability execution, or WP_Error on failure.
 	 */
 	public function execute( array $input = array() ) {
 		if ( ! $this->has_permission( $input ) ) {
@@ -326,6 +327,6 @@ class WP_Ability {
 	 * @since 0.1.0
 	 */
 	public function __wakeup(): void {
-		throw new \LogicException( __CLASS__ . ' should never be unserialized.' );
+		throw new \LogicException( self::class . ' should never be unserialized.' );
 	}
 }


### PR DESCRIPTION
## What

This is a first pass of PHPStan/PHPCS remediations. Most were auto-fixed, a couple (like moving the file headers above the `declare_strict()` ), 

Some tweaks to the `phpcs.xml.dist` as well, due to some accidental conflicts when I was deduping rulesets.


Follow up to #4 
---

Remaining smells are:

-  `WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound` - do we want a namespace?
- `WordPress.WP.I18n.MissingArgDomain` - do we want this translatable before merged into core?
- Missing array shapes - I just didnt have time right now to review the APIs and add them it but this is easy to do.

And then some things that need actual remediation (using `WP_Ability` as a string) or a decision about if we want to suppress/fix/turn off the rule.

## Why

1. In its current shape, it incrementally remediates making the "noise smaller" (and the merge conflicts fewer)
2. Lets us visually deliberate about rules we may or may not care about. 