### PR TITLE
ci: fix lint trigger on test GH workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - trunk
-    paths:
-      - .github/workflows/test.yml
   pull_request:
     types:
       - opened


### PR DESCRIPTION
## What

This fixes a bug in the GH workflow where the test CI was not being triggered by activity on `trunk`

## Why

Part of #13 

## How

The `push` call was unintentionally limited to changes in the workflow itself.