### PR TITLE
chore: align reqs with WP6.9 merge target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,7 +178,7 @@ jobs:
     strategy:
       matrix:
         php: ['8.4', '8.3', '8.2', '8.1', '8.0', '7.4']
-        wp: [latest, trunk, '6.7']
+        wp: [latest, trunk ]
         coverage: [false]
         include:
           - php: '8.4'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,10 @@ Join the `#core-ai` channel [on WordPress Slack](http://wordpress.slack.com) ([s
 
 ## Coding standards
 
-In general, all code must follow the [WordPress Coding Standards and best practices](https://developer.wordpress.org/coding-standards/). All code in the Performance Lab plugin must follow these requirements:
+In general, all code must follow the [WordPress Coding Standards and best practices](https://developer.wordpress.org/coding-standards/). All code in the Abilities API plugin must follow these requirements:
 
 - **WordPress**: As of Performance Lab v0.0.1, released {@todo}, the plugin's minimum WordPress version requirement is 6.7.
-- **PHP**: The minimum required version right now is 7.4. This is subject to change and will be brought in sync with the WordPress core minimum PHP version requirement closer to release.
+- **PHP**: The minimum required version of the code slated for WordPress Core includes is PHP7.2, but the tooling and development environment requires PHP 7.4 or higher.
 
 We include [several tools](#useful-commands) to help ensure your code meets contribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Join the `#core-ai` channel [on WordPress Slack](http://wordpress.slack.com) ([s
 
 In general, all code must follow the [WordPress Coding Standards and best practices](https://developer.wordpress.org/coding-standards/). All code in the Abilities API plugin must follow these requirements:
 
-- **WordPress**: As of Performance Lab v0.0.1, released {@todo}, the plugin's minimum WordPress version requirement is 6.7.
+- **WordPress**: The plugin's minimum WordPress version requirement is 6.8.
 - **PHP**: The minimum required version of the code slated for WordPress Core includes is PHP7.2, but the tooling and development environment requires PHP 7.4 or higher.
 
 We include [several tools](#useful-commands) to help ensure your code meets contribution

--- a/abilities-api.php
+++ b/abilities-api.php
@@ -11,9 +11,9 @@
  * Plugin Name:       Abilities API
  * Plugin URI:        https://github.com/WordPress/abilities-api
  * Description:       Provides a framework for registering and executing AI abilities in WordPress.
- * Requires at least: 6.7
+ * Requires at least: 6.8
  * Version:           0.0.1
- * Requires PHP:      7.4
+ * Requires PHP:      7.2
  * Author:            WordPress.org Contributors
  * Author URI:        https://github.com/WordPress/abilities-api/graphs/contributors
  * License:           GPLv2 or later

--- a/abilities-api.php
+++ b/abilities-api.php
@@ -12,7 +12,7 @@
  * Plugin URI:        https://github.com/WordPress/abilities-api
  * Description:       Provides a framework for registering and executing AI abilities in WordPress.
  * Requires at least: 6.8
- * Version:           0.0.1
+ * Version:           0.1.0
  * Requires PHP:      7.2
  * Author:            WordPress.org Contributors
  * Author URI:        https://github.com/WordPress/abilities-api/graphs/contributors
@@ -29,7 +29,7 @@ define( 'WP_ABILITIES_API_DIR', plugin_dir_path( __FILE__ ) );
 /**
  * Version of the plugin.
  */
-define( 'WP_ABILITIES_API_VERSION', '0.0.1' );
+define( 'WP_ABILITIES_API_VERSION', '0.1.0' );
 
 /**
  * First the WP_Ability class that users can extend.

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
 	"description": "AI Abilities for WordPress",
 	"license": "GPL-2.0-or-later",
 	"type": "wordpress-plugin",
+	"version": "0.1.0",
 	"keywords": [
 		"ai",
 		"llm",

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
@@ -69,7 +69,7 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 			array(
 				'args'   => array(
 					'name' => array(
-						'description' => __( 'Unique identifier for the ability.', 'abilities-api' ),
+						'description' => __( 'Unique identifier for the ability.' ),
 						'type'        => 'string',
 						'pattern'     => '^[a-zA-Z0-9\-\/]+$',
 					),
@@ -152,7 +152,7 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 		if ( ! $ability ) {
 			return new \WP_Error(
 				'rest_ability_not_found',
-				__( 'Ability not found.', 'abilities-api' ),
+				__( 'Ability not found.' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -233,37 +233,37 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'name'          => array(
-					'description' => __( 'Unique identifier for the ability.', 'abilities-api' ),
+					'description' => __( 'Unique identifier for the ability.' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
 				),
 				'label'         => array(
-					'description' => __( 'Display label for the ability.', 'abilities-api' ),
+					'description' => __( 'Display label for the ability.' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
 				),
 				'description'   => array(
-					'description' => __( 'Description of the ability.', 'abilities-api' ),
+					'description' => __( 'Description of the ability.' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'input_schema'  => array(
-					'description' => __( 'JSON Schema for the ability input.', 'abilities-api' ),
+					'description' => __( 'JSON Schema for the ability input.' ),
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'output_schema' => array(
-					'description' => __( 'JSON Schema for the ability output.', 'abilities-api' ),
+					'description' => __( 'JSON Schema for the ability output.' ),
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'meta'          => array(
-					'description' => __( 'Meta information about the ability.', 'abilities-api' ),
+					'description' => __( 'Meta information about the ability.' ),
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -286,7 +286,7 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 		return array(
 			'context'  => $this->get_context_param( array( 'default' => 'view' ) ),
 			'page'     => array(
-				'description'       => __( 'Current page of the collection.', 'abilities-api' ),
+				'description'       => __( 'Current page of the collection.' ),
 				'type'              => 'integer',
 				'default'           => 1,
 				'sanitize_callback' => 'absint',
@@ -294,7 +294,7 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 				'minimum'           => 1,
 			),
 			'per_page' => array(
-				'description'       => __( 'Maximum number of items to be returned in result set.', 'abilities-api' ),
+				'description'       => __( 'Maximum number of items to be returned in result set.' ),
 				'type'              => 'integer',
 				'default'           => self::DEFAULT_PER_PAGE,
 				'minimum'           => 1,

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
@@ -47,7 +47,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 			array(
 				'args'   => array(
 					'name' => array(
-						'description' => __( 'Unique identifier for the ability.', 'abilities-api' ),
+						'description' => __( 'Unique identifier for the ability.' ),
 						'type'        => 'string',
 						'pattern'     => '^[a-zA-Z0-9\-\/]+$',
 					),
@@ -84,7 +84,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 		if ( ! $ability ) {
 			return new \WP_Error(
 				'rest_ability_not_found',
-				__( 'Ability not found.', 'abilities-api' ),
+				__( 'Ability not found.' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -97,7 +97,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 		if ( 'resource' === $type && 'GET' !== $method ) {
 			return new \WP_Error(
 				'rest_invalid_method',
-				__( 'Resource abilities require GET method.', 'abilities-api' ),
+				__( 'Resource abilities require GET method.' ),
 				array( 'status' => 405 )
 			);
 		}
@@ -105,7 +105,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 		if ( 'tool' === $type && 'POST' !== $method ) {
 			return new \WP_Error(
 				'rest_invalid_method',
-				__( 'Tool abilities require POST method.', 'abilities-api' ),
+				__( 'Tool abilities require POST method.' ),
 				array( 'status' => 405 )
 			);
 		}
@@ -127,7 +127,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 		if ( ! $ability ) {
 			return new \WP_Error(
 				'rest_ability_not_found',
-				__( 'Ability not found.', 'abilities-api' ),
+				__( 'Ability not found.' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -156,7 +156,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 		if ( is_null( $result ) ) {
 			return new \WP_Error(
 				'rest_ability_execution_failed',
-				__( 'Ability execution failed. Please check permissions and input parameters.', 'abilities-api' ),
+				__( 'Ability execution failed. Please check permissions and input parameters.' ),
 				array( 'status' => 500 )
 			);
 		}
@@ -183,7 +183,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 		if ( ! $ability ) {
 			return new \WP_Error(
 				'rest_ability_not_found',
-				__( 'Ability not found.', 'abilities-api' ),
+				__( 'Ability not found.' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -193,7 +193,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 		if ( ! $ability->has_permission( $input ) ) {
 			return new \WP_Error(
 				'rest_cannot_execute',
-				__( 'Sorry, you are not allowed to execute this ability.', 'abilities-api' ),
+				__( 'Sorry, you are not allowed to execute this ability.' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}
@@ -223,7 +223,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 				'rest_invalid_param',
 				sprintf(
 					/* translators: %s: error message */
-					__( 'Invalid input parameters: %s', 'abilities-api' ),
+					__( 'Invalid input parameters: %s' ),
 					$validation_result->get_error_message()
 				),
 				array( 'status' => 400 )
@@ -255,7 +255,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 				'rest_invalid_response',
 				sprintf(
 					/* translators: %s: error message */
-					__( 'Invalid response from ability: %s', 'abilities-api' ),
+					__( 'Invalid response from ability: %s' ),
 					$validation_result->get_error_message()
 				),
 				array( 'status' => 500 )
@@ -299,7 +299,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 	public function get_run_args(): array {
 		return array(
 			'input' => array(
-				'description' => __( 'Input parameters for the ability execution.', 'abilities-api' ),
+				'description' => __( 'Input parameters for the ability execution.' ),
 				'type'        => 'object',
 				'default'     => array(),
 			),
@@ -320,7 +320,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'result' => array(
-					'description' => __( 'The result of the ability execution.', 'abilities-api' ),
+					'description' => __( 'The result of the ability execution.' ),
 					'type'        => 'mixed',
 					'context'     => array( 'view' ),
 					'readonly'    => true,

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -41,13 +41,13 @@
 		Tests for PHP version compatibility.
 	https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#Recomended-additional-rulesets
 	-->
-	<config name="testVersion" value="7.4-" />
+	<config name="testVersion" value="7.2-" />
 
 	<!--
 		Tests for WordPress version compatibility.
 	https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
 	-->
-	<config name="minimum_wp_version" value="6.7" />
+	<config name="minimum_wp_version" value="6.8" />
 
 	<!--
 		Load WordPress VIP Go standards
@@ -59,9 +59,8 @@
 		<exclude name="WordPressVIPMinimum.JS" />
 	</rule>
 	<rule ref="WordPress-Extra">
-		<!-- @todo: Determine a strategy on namespacing/merging into core. -->
 		<exclude name="WordPress.WP.I18n.MissingArgDomain" />
-		<exclude name="WordPress.NamingConventions.PrefixAllGlobals" />
+		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound" />
 		<!-- Needed to typehint, see: https://github.com/WordPress/WordPress-Coding-Standards/issues/403 -->
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
 	</rule>
@@ -196,12 +195,11 @@
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<property name="prefixes" type="array">
-				<!-- @todo: Should we use a namespace or prefix ? -->
-				<element value="abilities_api" />
+				<element value="abilities_api_" /><!-- Hook prefix -->
 				<element value="WP_Ability" />
 				<element value="WP_Abilities" />
-				<element value="WP_ABILITIES_API" />
 				<element value="WP_REST_Abilities" />
+				<element value="WP_ABILITIES_API" /> <!-- Constant -->
 			</property>
 		</properties>
 	</rule>
@@ -209,8 +207,8 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
-				<!-- Value: replace the text domain(s) used. -->
-				<element value="abilities-api" />
+				<!-- If flagged, remove the text-domain entirely. -->
+				<element value="" />
 			</property>
 		</properties>
 	</rule>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,7 @@ parameters:
 		# Configuration
 		level: 8
 		phpVersion:
-			min: 70400
+			min: 70200
 			max: 80300
 		bootstrapFiles:
 				- abilities-api.php


### PR DESCRIPTION
## What

This PR

- Drops the PHPCS/PHPStan min PHPVersion check to 7.2
- Bumps the min WordPress check to 6.8
- Removes the use of text-domains
- Updates the allowed prefixes
- Aligns the initial version number to 0.1.0

in accordance with a planned WordPress 6.9 merge.

## Why

We still benefit from the tooling by leaving the composer requirement at 7.4, but keep the codebase mergeable for 6.9 by linting against PHP 7.2.

Part of #13 


