### PR TITLE
dev: use `WP_Abilities_Registry::$instance` instead of adding a new `global`

### DIFF
--- a/includes/abilities-api/class-wp-abilities-registry.php
+++ b/includes/abilities-api/class-wp-abilities-registry.php
@@ -19,6 +19,14 @@ declare( strict_types = 1 );
  */
 final class WP_Abilities_Registry {
 	/**
+	 * The singleton instance of the registry.
+	 *
+	 * @since 0.1.0
+	 * @var ?self
+	 */
+	private static ?self $instance = null;
+
+	/**
 	 * Holds the registered abilities.
 	 *
 	 * @since 0.1.0
@@ -248,11 +256,9 @@ final class WP_Abilities_Registry {
 	 * @return \WP_Abilities_Registry The main registry instance.
 	 */
 	public static function get_instance(): self {
-		/** @var \WP_Abilities_Registry $wp_abilities */
-		global $wp_abilities;
+		if ( null === self::$instance ) {
+			self::$instance = new self();
 
-		if ( empty( $wp_abilities ) ) {
-			$wp_abilities = new self();
 			/**
 			 * Fires when preparing abilities registry.
 			 *
@@ -263,10 +269,10 @@ final class WP_Abilities_Registry {
 			 *
 			 * @param \WP_Abilities_Registry $instance Abilities registry object.
 			 */
-			do_action( 'abilities_api_init', $wp_abilities );
+			do_action( 'abilities_api_init', self::$instance );
 		}
 
-		return $wp_abilities;
+		return self::$instance;
 	}
 
 	/**

--- a/includes/abilities-api/class-wp-abilities-registry.php
+++ b/includes/abilities-api/class-wp-abilities-registry.php
@@ -24,7 +24,7 @@ final class WP_Abilities_Registry {
 	 * @since 0.1.0
 	 * @var ?self
 	 */
-	private static ?self $instance = null;
+	private static $instance = null;
 
 	/**
 	 * Holds the registered abilities.

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -43,10 +43,10 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 				'description' => 'The result of adding the two numbers.',
 				'required'    => true,
 			),
-			'execute_callback'    => function ( array $input ): int {
+			'execute_callback'    => static function ( array $input ): int {
 				return $input['a'] + $input['b'];
 			},
-			'permission_callback' => function (): bool {
+			'permission_callback' => static function (): bool {
 				return true;
 			},
 			'meta'                => array(
@@ -60,9 +60,11 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	 */
 	public function tear_down(): void {
 		foreach ( wp_get_abilities() as $ability ) {
-			if ( str_starts_with( $ability->get_name(), 'test/' ) ) {
-				wp_unregister_ability( $ability->get_name() );
+			if ( ! str_starts_with( $ability->get_name(), 'test/' ) ) {
+				continue;
 			}
+
+			wp_unregister_ability( $ability->get_name() );
 		}
 
 		parent::tear_down();
@@ -147,7 +149,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	public function test_register_ability_no_permissions(): void {
 		do_action( 'abilities_api_init' );
 
-		self::$test_ability_properties['permission_callback'] = function (): bool {
+		self::$test_ability_properties['permission_callback'] = static function (): bool {
 			return false;
 		};
 		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_properties );
@@ -200,7 +202,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	public function test_execute_ability_no_output_schema_match(): void {
 		do_action( 'abilities_api_init' );
 
-		self::$test_ability_properties['execute_callback'] = function (): bool {
+		self::$test_ability_properties['execute_callback'] = static function (): bool {
 			return true;
 		};
 		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_properties );
@@ -243,7 +245,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 		do_action( 'abilities_api_init' );
 
 		$received_input                                       = null;
-		self::$test_ability_properties['permission_callback'] = function ( array $input ) use ( &$received_input ): bool {
+		self::$test_ability_properties['permission_callback'] = static function ( array $input ) use ( &$received_input ): bool {
 			$received_input = $input;
 			// Allow only if 'a' is greater than 'b'
 			return $input['a'] > $input['b'];
@@ -310,25 +312,26 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 
 		$name       = self::$test_ability_name;
 		$properties = self::$test_ability_properties;
-		$callback   = function ( $instance ) use ( $name, $properties ) {
+		$callback   = static function ( $instance ) use ( $name, $properties ) {
 			wp_register_ability( $name, $properties );
 		};
 
 		add_action( 'abilities_api_init', $callback );
 
-		// Temporarily set `$wp_abilities` to null to ensure `wp_get_ability()` triggers `abilities_api_init` action.
-		$old_wp_abilities = $wp_abilities;
-		$wp_abilities     = null;
+		// Reset the Registry, to ensure it's empty before the test.
+		$registry_reflection = new ReflectionClass( WP_Abilities_Registry::class );
+		$instance_prop       = $registry_reflection->getProperty( 'instance' );
+		$instance_prop->setAccessible( true );
+		$instance_prop->setValue( null );
 
 		$result = wp_get_ability( $name );
-
-		$wp_abilities = $old_wp_abilities;
 
 		remove_action( 'abilities_api_init', $callback );
 
 		$this->assertEquals(
 			new WP_Ability( $name, $properties ),
-			$result
+			$result,
+			'Ability does not share expected properties.'
 		);
 	}
 


### PR DESCRIPTION
## What

This PR changes `WP_Abilities_Registry` to store it's instance on `::$instance`, instead of on a new `global $wp_abilities` variable.

(Note: I'm just code-reviewing and leaving feedback. If you think this warrants a wider discussion I can open a matching issue, otherwise I think a discussion here following by [accept | reject] is enough)

## Why

Global variables are hard-to-type-and-test antipatterns. Just because legacy WP code used them before there were better patterns doesn't mean we need to introduce new ones.  

Using a private instance gives core contributors _and_ end-devs more insight into usage, and as developers working on the Abilities API, we get a much smaller surface for breaking changes to worry about. 
