### PR TITLE
code quality: add PHPStan array shape for ability `$properties`

### DIFF
--- a/includes/abilities-api.php
+++ b/includes/abilities-api.php
@@ -27,6 +27,17 @@ declare( strict_types = 1 );
  *                                        include `label`, `description`, `input_schema`, `output_schema`,
  *                                        `execute_callback`, `permission_callback`, and `meta`.
  * @return ?\WP_Ability An instance of registered ability on success, null on failure.
+ *
+ * @phpstan-param array{
+ *   label?: string,
+ *   description?: string,
+ *   input_schema?: array<string,mixed>,
+ *   output_schema?: array<string,mixed>,
+ *   execute_callback?: callable( array<string,mixed> $input): (mixed|\WP_Error),
+ *   permission_callback?: callable( ?array<string,mixed> $input ): bool,
+ *   meta?: array<string,mixed>,
+ *   ...<string, mixed>
+ * } $properties
  */
 function wp_register_ability( $name, array $properties = array() ): ?WP_Ability {
 	if ( ! did_action( 'abilities_api_init' ) ) {

--- a/includes/abilities-api/class-wp-abilities-registry.php
+++ b/includes/abilities-api/class-wp-abilities-registry.php
@@ -42,6 +42,17 @@ final class WP_Abilities_Registry {
 	 *                                        include `label`, `description`, `input_schema`, `output_schema`,
 	 *                                        `execute_callback`, `permission_callback`, and `meta`.
 	 * @return ?\WP_Ability The registered ability instance on success, null on failure.
+	 *
+	 * @phpstan-param array{
+	 *   label?: string,
+	 *   description?: string,
+	 *   input_schema?: array<string,mixed>,
+	 *   output_schema?: array<string,mixed>,
+	 *   execute_callback?: callable( array<string,mixed> $input): (mixed|\WP_Error),
+	 *   permission_callback?: ?callable( ?array<string,mixed> $input ): bool,
+	 *   meta?: array<string,mixed>,
+	 *   ...<string, mixed>
+	 * } $properties
 	 */
 	public function register( $name, array $properties = array() ): ?WP_Ability {
 		$ability = null;

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -99,6 +99,16 @@ class WP_Ability {
 	 * @param array<string,mixed> $properties An associative array of properties for the ability. This should
 	 *                                        include `label`, `description`, `input_schema`, `output_schema`,
 	 *                                        `execute_callback`, `permission_callback`, and `meta`.
+	 *
+	 * @phpstan-param array{
+	 *   label: string,
+	 *   description: string,
+	 *   input_schema?: array<string,mixed>,
+	 *   output_schema?: array<string,mixed>,
+	 *   execute_callback: callable( array<string,mixed> $input): (mixed|\WP_Error),
+	 *   permission_callback?: ?callable( ?array<string,mixed> $input ): bool,
+	 *   meta?: array<string,mixed>,
+	 * } $properties
 	 */
 	public function __construct( string $name, array $properties ) {
 		$this->name = $name;


### PR DESCRIPTION
## What

This PR adds array shapes for the `$properties` array used by 

- `wp_register_ability()`
- `WP_Abilities_Registry::register()`
- `WP_Ability::__construct()`

## Why

To ensure both we and consumers are using the correct array shapes.

## Additional Notes

- Generics are _not_ used e.g. to hint the schema/meta shapes. Until core supports generics, that extra level of DX would fall to a 3rd party library like `php-stubs/wordpress-stubs`.
- As a result of the array shapes we could in theory make the param less verbose, but human contribs might not be familiar with the syntax, so I left it out. 