### PR TITLE
ci: build zip file for GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,6 @@ jobs:
         env:
           CI: true
 
-      - name: Build assets
-        run: npm run build:dist
-
       - name: Create Artifact
         run: |
           npm run plugin-zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Upload Package on Release
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  tag:
+    name: Upload New Release
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+          persist-credentials: false
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+        with:
+          php-version: '8.3'
+          coverage: none
+          tools: composer:v2
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@a2636af0004d1c0499ffca16ac0b4cc94df70565 # v3.1.0
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+
+      - name: Install NPM dependencies
+        run: npm ci
+        env:
+          CI: true
+
+      - name: Build assets
+        run: npm run build:dist
+
+      - name: Create Artifact
+        run: |
+          npm run plugin-zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: abilities-api
+          path: abilities-api.zip
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
+        with:
+          files: abilities-api.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"@wordpress/prettier-config": "^4.28.0"
 	},
 	"files": [
-		"src",
+		"includes",
 		"LICENSE",
 		"CHANGELOG.md",
 		"README.md",


### PR DESCRIPTION
## What

This PR adds a GitHub workflow to create a distribution build of the plugin, and attach it to the GitHub release.

## Why

Provides closure on distribution methods:

1. Download and install manually from the latest release: https://github.com/WordPress/abilities-api/releases/latest
2. Download and install with wp-cli: `wp plugin install https://github.com/WordPress/abilities-api/releases/latest/download/abilities-api.zip`
3. Require with composer:
    ```json
     {
       "repositories": [
         {
           "type": "vcs",
           "url": "https://github.com/WordPress/abilities-api.git"
         }
       ],
     }
    ```
   `composer require wordpress/abilities-api --save` 
   
## To Test

1. Replace `wordpress/abilities-api` with my fork: `justlevine/abilities-api`
2. Workflow https://github.com/justlevine/abilities-api/actions/runs/17013511598/job/48232662144 