### PR TITLE
Chore: Fix coding standard issues reported on wordpress-develop

### DIFF
--- a/tests/unit/rest-api/wpRestAbilitiesListController.php
+++ b/tests/unit/rest-api/wpRestAbilitiesListController.php
@@ -43,7 +43,9 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 
 		// Set up REST server
 		global $wp_rest_server;
-		$this->server = $wp_rest_server = new WP_REST_Server();
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
 		do_action( 'rest_api_init' );
 
 		// Initialize abilities API
@@ -107,7 +109,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 						case 'multiply':
 							return $input['a'] * $input['b'];
 						case 'divide':
-							return $input['b'] !== 0 ? $input['a'] / $input['b'] : null;
+							return 0 !== $input['b'] ? $input['a'] / $input['b'] : null;
 						default:
 							return null;
 					}
@@ -193,7 +195,6 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 		$data = $response->get_data();
 		$this->assertIsArray( $data );
 		$this->assertNotEmpty( $data );
-
 
 		$this->assertCount( 50, $data, 'First page should return exactly 50 items (default per_page)' );
 
@@ -292,7 +293,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 
 		// Test last page (should have 'prev' link but no 'next')
 		$total_abilities = count( wp_get_abilities() );
-		$last_page = ceil( $total_abilities / 10 );
+		$last_page       = ceil( $total_abilities / 10 );
 		$request->set_param( 'page', $last_page );
 		$response = $this->server->dispatch( $request );
 
@@ -378,7 +379,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 	 * Test schema retrieval.
 	 */
 	public function test_get_schema(): void {
-		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/abilities' );
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/abilities' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -406,9 +407,9 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 		wp_register_ability(
 			'test-hyphen/ability',
 			array(
-				'label'            => 'Test Hyphen Ability',
-				'description'      => 'Test ability with hyphen',
-				'execute_callback' => function( $input ) {
+				'label'               => 'Test Hyphen Ability',
+				'description'         => 'Test ability with hyphen',
+				'execute_callback'    => function ( $input ) {
 					return array( 'success' => true );
 				},
 				'permission_callback' => '__return_true',
@@ -416,7 +417,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 		);
 
 		// Test valid special characters (hyphen, forward slash)
-		$request = new WP_REST_Request( 'GET', '/wp/v2/abilities/test-hyphen/ability' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/abilities/test-hyphen/ability' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 	}
@@ -446,7 +447,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 	 * @param string $name Invalid ability name to test.
 	 */
 	public function test_ability_name_with_invalid_special_characters( string $name ): void {
-		$request = new WP_REST_Request( 'GET', '/wp/v2/abilities/' . $name );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/abilities/' . $name );
 		$response = $this->server->dispatch( $request );
 		// Should return 404 as the regex pattern won't match
 		$this->assertEquals( 404, $response->get_status() );
@@ -461,7 +462,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 		// Create a very long but valid ability name
 		$long_name = 'test/' . str_repeat( 'a', 1000 );
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/abilities/' . $long_name );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/abilities/' . $long_name );
 		$response = $this->server->dispatch( $request );
 
 		// Should return 404 as ability doesn't exist

--- a/tests/unit/rest-api/wpRestAbilitiesRunController.php
+++ b/tests/unit/rest-api/wpRestAbilitiesRunController.php
@@ -54,7 +54,9 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		parent::set_up();
 
 		global $wp_rest_server;
-		$this->server = $wp_rest_server = new WP_REST_Server();
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
 		do_action( 'rest_api_init' );
 
 		do_action( 'abilities_api_init' );
@@ -526,16 +528,18 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 	 */
 	public function test_get_request_with_nested_input_array(): void {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/abilities/test/query-params/run' );
-		$request->set_query_params( array(
-			'input' => array(
-				'level1' => array(
-					'level2' => array(
-						'value' => 'nested',
+		$request->set_query_params(
+			array(
+				'input' => array(
+					'level1' => array(
+						'level2' => array(
+							'value' => 'nested',
+						),
 					),
+					'array'  => array( 1, 2, 3 ),
 				),
-				'array' => array( 1, 2, 3 ),
-			),
-		) );
+			)
+		);
 
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
@@ -550,9 +554,11 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 	 */
 	public function test_get_request_with_non_array_input(): void {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/abilities/test/query-params/run' );
-		$request->set_query_params( array(
-			'input' => 'not-an-array', // String instead of array
-		) );
+		$request->set_query_params(
+			array(
+				'input' => 'not-an-array', // String instead of array
+			)
+		);
 
 		$response = $this->server->dispatch( $request );
 		// When input is not an array, WordPress returns 400 Bad Request
@@ -565,9 +571,13 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 	public function test_post_request_with_non_array_input(): void {
 		$request = new WP_REST_Request( 'POST', '/wp/v2/abilities/test/calculator/run' );
 		$request->set_header( 'Content-Type', 'application/json' );
-		$request->set_body( wp_json_encode( array(
-			'input' => 'string-value', // String instead of array
-		) ) );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'input' => 'string-value', // String instead of array
+				)
+			)
+		);
 
 		$response = $this->server->dispatch( $request );
 		// When input is not an array, WordPress returns 400 Bad Request
@@ -583,9 +593,9 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		wp_register_ability(
 			'test/strict-output',
 			array(
-				'label'            => 'Strict Output',
-				'description'      => 'Ability with strict output schema',
-				'output_schema'    => array(
+				'label'               => 'Strict Output',
+				'description'         => 'Ability with strict output schema',
+				'output_schema'       => array(
 					'type'       => 'object',
 					'properties' => array(
 						'status' => array(
@@ -595,12 +605,12 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					),
 					'required'   => array( 'status' ),
 				),
-				'execute_callback' => function( $input ) {
+				'execute_callback'    => function ( $input ) {
 					// Return invalid output that doesn't match schema
 					return array( 'wrong_field' => 'value' );
 				},
 				'permission_callback' => '__return_true',
-				'meta'             => array( 'type' => 'tool' ),
+				'meta'                => array( 'type' => 'tool' ),
 			)
 		);
 
@@ -625,9 +635,9 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		wp_register_ability(
 			'test/strict-input',
 			array(
-				'label'         => 'Strict Input',
-				'description'   => 'Ability with strict input schema',
-				'input_schema'  => array(
+				'label'               => 'Strict Input',
+				'description'         => 'Ability with strict input schema',
+				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(
 						'required_field' => array(
@@ -636,11 +646,11 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					),
 					'required'   => array( 'required_field' ),
 				),
-				'execute_callback' => function( $input ) {
+				'execute_callback'    => function ( $input ) {
 					return array( 'status' => 'success' );
 				},
 				'permission_callback' => '__return_true',
-				'meta'          => array( 'type' => 'tool' ),
+				'meta'                => array( 'type' => 'tool' ),
 			)
 		);
 
@@ -665,18 +675,18 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		wp_register_ability(
 			'test/no-type',
 			array(
-				'label'            => 'No Type',
-				'description'      => 'Ability without type',
-				'execute_callback' => function( $input ) {
+				'label'               => 'No Type',
+				'description'         => 'Ability without type',
+				'execute_callback'    => function ( $input ) {
 					return array( 'executed' => true );
 				},
 				'permission_callback' => '__return_true',
-				'meta'             => array(), // No type specified
+				'meta'                => array(), // No type specified
 			)
 		);
 
 		// Should require POST (default tool behavior)
-		$get_request = new WP_REST_Request( 'GET', '/wp/v2/abilities/test/no-type/run' );
+		$get_request  = new WP_REST_Request( 'GET', '/wp/v2/abilities/test/no-type/run' );
 		$get_response = $this->server->dispatch( $get_request );
 		$this->assertEquals( 405, $get_response->get_status() );
 
@@ -699,7 +709,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 			array(
 				'label'            => 'No Permission Callback',
 				'description'      => 'Ability without permission callback',
-				'execute_callback' => function( $input ) {
+				'execute_callback' => function ( $input ) {
 					return array( 'executed' => true );
 				},
 				'meta'             => array( 'type' => 'tool' ),
@@ -730,31 +740,31 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		wp_register_ability(
 			'test/resource-empty',
 			array(
-				'label'            => 'Resource Empty',
-				'description'      => 'Resource with empty input',
-				'execute_callback' => function( $input ) {
+				'label'               => 'Resource Empty',
+				'description'         => 'Resource with empty input',
+				'execute_callback'    => function ( $input ) {
 					return array( 'input_was_empty' => empty( $input ) );
 				},
 				'permission_callback' => '__return_true',
-				'meta'             => array( 'type' => 'resource' ),
+				'meta'                => array( 'type' => 'resource' ),
 			)
 		);
 
 		wp_register_ability(
 			'test/tool-empty',
 			array(
-				'label'            => 'Tool Empty',
-				'description'      => 'Tool with empty input',
-				'execute_callback' => function( $input ) {
+				'label'               => 'Tool Empty',
+				'description'         => 'Tool with empty input',
+				'execute_callback'    => function ( $input ) {
 					return array( 'input_was_empty' => empty( $input ) );
 				},
 				'permission_callback' => '__return_true',
-				'meta'             => array( 'type' => 'tool' ),
+				'meta'                => array( 'type' => 'tool' ),
 			)
 		);
 
 		// Test GET with no input parameter
-		$get_request = new WP_REST_Request( 'GET', '/wp/v2/abilities/test/resource-empty/run' );
+		$get_request  = new WP_REST_Request( 'GET', '/wp/v2/abilities/test/resource-empty/run' );
 		$get_response = $this->server->dispatch( $get_request );
 		$this->assertEquals( 200, $get_response->get_status() );
 		$this->assertTrue( $get_response->get_data()['input_was_empty'] );
@@ -813,13 +823,13 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		wp_register_ability(
 			'test/echo',
 			array(
-				'label'            => 'Echo',
-				'description'      => 'Echoes input',
-				'execute_callback' => function( $input ) {
+				'label'               => 'Echo',
+				'description'         => 'Echoes input',
+				'execute_callback'    => function ( $input ) {
 					return array( 'echo' => $input );
 				},
 				'permission_callback' => '__return_true',
-				'meta'             => array( 'type' => 'tool' ),
+				'meta'                => array( 'type' => 'tool' ),
 			)
 		);
 
@@ -854,13 +864,13 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		wp_register_ability(
 			'test/echo-encoding',
 			array(
-				'label'            => 'Echo Encoding',
-				'description'      => 'Echoes input with encoding',
-				'execute_callback' => function( $input ) {
+				'label'               => 'Echo Encoding',
+				'description'         => 'Echoes input with encoding',
+				'execute_callback'    => function ( $input ) {
 					return array( 'echo' => $input );
 				},
 				'permission_callback' => '__return_true',
-				'meta'             => array( 'type' => 'tool' ),
+				'meta'                => array( 'type' => 'tool' ),
 			)
 		);
 
@@ -916,7 +926,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 			array(
 				'label'               => 'Method Test',
 				'description'         => 'Test ability for HTTP method validation',
-				'execute_callback'    => function() {
+				'execute_callback'    => function () {
 					return array( 'success' => true );
 				},
 				'permission_callback' => '__return_true', // No permission requirements
@@ -924,7 +934,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 			)
 		);
 
-		$request = new WP_REST_Request( $method, '/wp/v2/abilities/test/method-test/run' );
+		$request  = new WP_REST_Request( $method, '/wp/v2/abilities/test/method-test/run' );
 		$response = $this->server->dispatch( $request );
 
 		// Tool abilities should only accept POST, so these should return 405
@@ -937,10 +947,9 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 	 * Test OPTIONS method handling.
 	 */
 	public function test_options_method_handling(): void {
-		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/abilities/test/calculator/run' );
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/abilities/test/calculator/run' );
 		$response = $this->server->dispatch( $request );
 		// OPTIONS requests return 200 with allowed methods
 		$this->assertEquals( 200, $response->get_status() );
 	}
-
 }


### PR DESCRIPTION
I synced all the changes added to this repository on Wordpress-develop:
- https://github.com/WordPress/wordpress-develop/pull/9410

This PR fixes all the coding standard issues reported. Most of them were fixed with the `composer format` command executed in the linked repository.