### PR TITLE
ci: fixes and cleanup

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -38,13 +38,8 @@ jobs:
         with:
           php-version: '8.3'
           coverage: none
-
-      # Since Composer dependencies are installed using `composer update` and no lock file is in version control,
-      # passing a custom cache suffix ensures that the cache is flushed at least once per week.
       - name: Install Composer dependencies
         uses: ramsey/composer-install@a2636af0004d1c0499ffca16ac0b4cc94df70565 # v3.1.0
-        with:
-          custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
   # - Sets up PHP.
   # - Configures caching for PHPCS scans.
   # - Installs Composer dependencies.
-  # - Make Composer packages available globally.
   # - Runs PHPCS on the full codebase.
   # - Generate a report for displaying issues as pull request annotations.
   phpcs:
@@ -68,11 +67,6 @@ jobs:
       # passing a custom cache suffix ensures that the cache is flushed at least once per week.
       - name: Install Composer dependencies
         uses: ramsey/composer-install@a2636af0004d1c0499ffca16ac0b4cc94df70565 # v3.1.0
-        with:
-          custom-cache-suffix: ${{ steps.get-date.outputs.date }}
-
-      - name: Make Composer packages available globally
-        run: echo "${PWD}/vendor/bin" >> "$GITHUB_PATH"
 
       - name: Run PHPCS
         id: phpcs
@@ -89,12 +83,11 @@ jobs:
   # Performs the following steps:
   # - Checks out the repository.
   # - Sets up PHP.
-  # - Installs Composer dependencies.
   # - Configures caching for PHP static analysis scans.
-  # - Make Composer packages available globally.
+  # - Installs Composer dependencies.
+  # - Makes Composer packages available globally.
   # - Runs PHPStan static analysis (with Pull Request annotations).
   # - Saves the PHPStan result cache.
-  # - Ensures version-controlled files are not modified or deleted.
   phpstan:
     name: Run PHP static analysis
     runs-on: ubuntu-24.04
@@ -116,29 +109,25 @@ jobs:
           coverage: none
           tools: cs2pr
 
-      # This date is used to ensure that the Composer cache is cleared at least once every week.
+      # This date is used to ensure that the PHPCS cache is cleared at least once every week.
       # http://man7.org/linux/man-pages/man1/date.1.html
       - name: "Get last Monday's date"
         id: get-date
         run: echo "date=$(/bin/date -u --date='last Mon' "+%F")" >> "$GITHUB_OUTPUT"
 
-      # Since Composer dependencies are installed using `composer update` and no lock file is in version control,
-      # passing a custom cache suffix ensures that the cache is flushed at least once per week.
-      - name: Install Composer dependencies
-        uses: ramsey/composer-install@a2636af0004d1c0499ffca16ac0b4cc94df70565 # v3.1.0
-        with:
-          custom-cache-suffix: ${{ steps.get-date.outputs.date }}
-
-      - name: Make Composer packages available globally
-        run: echo "${PWD}/vendor/bin" >> "$GITHUB_PATH"
-
       - name: Cache PHP Static Analysis scan cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: tests/_output # This is defined in the base.neon file.
-          key: 'phpstan-result-cache-${{ github.run_id }}'
+          key: 'phpstan-result-cache-${{ runner.os }}-date-${{ steps.get-date.outputs.date }}'
           restore-keys: |
             phpstan-result-cache-
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@a2636af0004d1c0499ffca16ac0b4cc94df70565 # v3.1.0
+
+      - name: Make Composer packages available globally
+        run: echo "${PWD}/vendor/bin" >> "$GITHUB_PATH"
 
       - name: Run PHP static analysis tests
         id: phpstan
@@ -149,29 +138,22 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           path: tests/_output
-          key: 'phpstan-result-cache-${{ github.run_id }}'
+          key: 'phpstan-result-cache-${{ runner.os }}-date-${{ steps.get-date.outputs.date }}'
 
   # Runs the PHPUnit tests for WordPress.
   #
   # Performs the following steps:
   # - Sets environment variables.
   # - Checks out the repository.
-  # - Sets up Node.js.
   # - Sets up PHP.
   # - Installs Composer dependencies.
-  # - Installs npm dependencies
-  # - Logs general debug information about the runner.
-  # - Logs Docker debug information (about the Docker installation within the runner).
-  # - Starts the WordPress Docker container.
-  # - Logs the running Docker containers.
-  # - Logs debug information about what's installed within the WordPress Docker containers.
-  # - Install WordPress within the Docker container.
-  # - Run the PHPUnit tests.
-  # - Upload the code coverage report to Codecov.io.
-  # - Upload the HTML code coverage report as an artifact.
-  # - Ensures version-controlled files are not modified or deleted.
-  # - Checks out the WordPress Test reporter repository.
-  # - Submit the test results to the WordPress.org host test results.
+  # - Sets up Node.js.
+  # - Installs npm dependencies.
+  # - Starts the WordPress Docker testing environment (with or without Xdebug coverage).
+  # - Logs PHP and WordPress versions from the container.
+  # - Runs PHPUnit tests (with coverage if enabled).
+  # - Uploads code coverage report to Codecov.io (if coverage is enabled).
+  # - Uploads HTML coverage report as an artifact (if coverage is enabled).
   phpunit:
     name: Test PHP ${{ matrix.php }} WP ${{ matrix.wp }}${{ matrix.coverage && ' with coverage' || '' }}
     runs-on: ubuntu-24.04
@@ -179,7 +161,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.4', '8.3', '8.2', '8.1', '8.0', '7.4']
-        wp: [latest, trunk ]
+        wp: [latest, trunk]
         coverage: [false]
         include:
           - php: '8.4'
@@ -214,12 +196,8 @@ jobs:
           php-version: '${{ matrix.php }}'
           coverage: none
 
-      # Since Composer dependencies are installed using `composer update` and no lock file is in version control,
-      # passing a custom cache suffix ensures that the cache is flushed at least once per week.
       - name: Install Composer dependencies
         uses: ramsey/composer-install@a2636af0004d1c0499ffca16ac0b4cc94df70565 # v3.1.0
-        with:
-          custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,6 +176,7 @@ jobs:
     name: Test PHP ${{ matrix.php }} WP ${{ matrix.wp }}${{ matrix.coverage && ' with coverage' || '' }}
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         php: ['8.4', '8.3', '8.2', '8.1', '8.0', '7.4']
         wp: [latest, trunk ]
@@ -247,7 +248,6 @@ jobs:
           npm run wp-env -- run cli wp core version
 
       - name: Run PHPUnit tests${{ matrix.coverage && ' with coverage report' || '' }}
-        continue-on-error: true
         id: phpunit
         run: |
           npm run test:php


### PR DESCRIPTION
## What

This PR

1. Fixes the `phpunit` job to fail if `npm run test:php` fails
2. Cleans up some unnecessary caching values that leaked in from `wordpress-develop`.
3. Updates the job comments to reflect the current state of the jobs.

## Why
- https://github.com/WordPress/abilities-api/pull/19#issuecomment-3195288405
- Part of #13