### PR TITLE
Refactor error handling in REST API run controller

### DIFF
--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -199,8 +199,19 @@ class WP_Ability {
 		}
 
 		$valid_input = rest_validate_value_from_schema( $input, $input_schema );
+		if ( is_wp_error( $valid_input ) ) {
+			return new \WP_Error(
+				'ability_invalid_input',
+				/* translators: %1$s ability name, %2$s error message. */
+				sprintf(
+					__( 'Ability "%1$s" has invalid input. Reason: %2$s.' ),
+					$this->name,
+					$valid_input->get_error_message()
+				)
+			);
+		}
 
-		return is_wp_error( $valid_input ) ? $valid_input : true;
+		return true;
 	}
 
 	/**
@@ -261,8 +272,19 @@ class WP_Ability {
 		}
 
 		$valid_output = rest_validate_value_from_schema( $output, $output_schema );
+		if ( is_wp_error( $valid_output ) ) {
+			return new \WP_Error(
+				'ability_invalid_output',
+				/* translators: %1$s ability name, %2$s error message. */
+				sprintf(
+					__( 'Ability "%1$s" has invalid output. Reason: %2$s.' ),
+					$this->name,
+					$valid_output->get_error_message()
+				)
+			);
+		}
 
-		return is_wp_error( $valid_output ) ? $valid_output : true;
+		return true;
 	}
 
 	/**
@@ -276,10 +298,12 @@ class WP_Ability {
 	 */
 	public function execute( array $input = array() ) {
 		$has_permissions = $this->has_permission( $input );
-
 		if ( true !== $has_permissions ) {
 			if ( is_wp_error( $has_permissions ) ) {
-				// Don't leak the error to someone without the correct perms.
+				if ( 'ability_invalid_input' === $has_permissions->get_error_code() ) {
+					return $has_permissions;
+				}
+				// Don't leak the permission check error to someone without the correct perms.
 				_doing_it_wrong(
 					__METHOD__,
 					esc_html( $has_permissions->get_error_message() ),

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -198,13 +198,13 @@ class WP_Ability {
 			return true;
 		}
 
-		$valid_input = rest_validate_value_from_schema( $input, $input_schema );
+		$valid_input = rest_validate_value_from_schema( $input, $input_schema, 'input' );
 		if ( is_wp_error( $valid_input ) ) {
 			return new \WP_Error(
 				'ability_invalid_input',
 				sprintf(
 					/* translators: %1$s ability name, %2$s error message. */
-					__( 'Ability "%1$s" has invalid input. Reason: %2$s.' ),
+					__( 'Ability "%1$s" has invalid input. Reason: %2$s' ),
 					$this->name,
 					$valid_input->get_error_message()
 				)
@@ -271,13 +271,13 @@ class WP_Ability {
 			return true;
 		}
 
-		$valid_output = rest_validate_value_from_schema( $output, $output_schema );
+		$valid_output = rest_validate_value_from_schema( $output, $output_schema, 'output' );
 		if ( is_wp_error( $valid_output ) ) {
 			return new \WP_Error(
 				'ability_invalid_output',
 				sprintf(
 					/* translators: %1$s ability name, %2$s error message. */
-					__( 'Ability "%1$s" has invalid output. Reason: %2$s.' ),
+					__( 'Ability "%1$s" has invalid output. Reason: %2$s' ),
 					$this->name,
 					$valid_output->get_error_message()
 				)

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -202,8 +202,8 @@ class WP_Ability {
 		if ( is_wp_error( $valid_input ) ) {
 			return new \WP_Error(
 				'ability_invalid_input',
-				/* translators: %1$s ability name, %2$s error message. */
 				sprintf(
+					/* translators: %1$s ability name, %2$s error message. */
 					__( 'Ability "%1$s" has invalid input. Reason: %2$s.' ),
 					$this->name,
 					$valid_input->get_error_message()
@@ -275,8 +275,8 @@ class WP_Ability {
 		if ( is_wp_error( $valid_output ) ) {
 			return new \WP_Error(
 				'ability_invalid_output',
-				/* translators: %1$s ability name, %2$s error message. */
 				sprintf(
+					/* translators: %1$s ability name, %2$s error message. */
 					__( 'Ability "%1$s" has invalid output. Reason: %2$s.' ),
 					$this->name,
 					$valid_output->get_error_message()

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
@@ -96,7 +96,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 
 		if ( 'resource' === $type && 'GET' !== $method ) {
 			return new \WP_Error(
-				'rest_invalid_method',
+				'rest_ability_invalid_method',
 				__( 'Resource abilities require GET method.' ),
 				array( 'status' => 405 )
 			);
@@ -104,7 +104,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 
 		if ( 'tool' === $type && 'POST' !== $method ) {
 			return new \WP_Error(
-				'rest_invalid_method',
+				'rest_ability_invalid_method',
 				__( 'Tool abilities require POST method.' ),
 				array( 'status' => 405 )
 			);
@@ -123,7 +123,6 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 	 */
 	public function run_ability( $request ) {
 		$ability = wp_get_ability( $request->get_param( 'name' ) );
-
 		if ( ! $ability ) {
 			return new \WP_Error(
 				'rest_ability_not_found',
@@ -132,26 +131,13 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 			);
 		}
 
-		$input = $this->get_input_from_request( $request );
-
-		// REST API needs detailed error messages with HTTP status codes.
-		// While WP_Ability::execute() validates internally, it only returns false
-		// and logs with _doing_it_wrong, which doesn't provide capturable error messages.
-		// TODO: Consider updating WP_Ability to return WP_Error for better error handling.
-		$input_validation = $this->validate_input( $ability, $input );
-		if ( is_wp_error( $input_validation ) ) {
-			return $input_validation;
-		}
-
+		$input  = $this->get_input_from_request( $request );
 		$result = $ability->execute( $input );
-
 		if ( is_wp_error( $result ) ) {
+			if ( 'ability_invalid_input' === $result->get_error_code() ) {
+				$result->add_data( array( 'status' => 400 ) );
+			}
 			return $result;
-		}
-
-		$output_validation = $this->validate_output( $ability, $result );
-		if ( is_wp_error( $output_validation ) ) {
-			return $output_validation;
 		}
 
 		return rest_ensure_response( $result );
@@ -167,7 +153,6 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 	 */
 	public function run_ability_permissions_check( $request ) {
 		$ability = wp_get_ability( $request->get_param( 'name' ) );
-
 		if ( ! $ability ) {
 			return new \WP_Error(
 				'rest_ability_not_found',
@@ -177,76 +162,11 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 		}
 
 		$input = $this->get_input_from_request( $request );
-
 		if ( ! $ability->has_permission( $input ) ) {
 			return new \WP_Error(
-				'rest_cannot_execute',
+				'rest_ability_cannot_execute',
 				__( 'Sorry, you are not allowed to execute this ability.' ),
 				array( 'status' => rest_authorization_required_code() )
-			);
-		}
-
-		return true;
-	}
-
-	/**
-	 * Validates input data against the ability's input schema.
-	 *
-	 * @since 0.1.0
-	 *
-	 * @param \WP_Ability          $ability The ability object.
-	 * @param array<string, mixed> $input   The input data to validate.
-	 * @return true|\WP_Error True if validation passes, WP_Error object on failure.
-	 */
-	private function validate_input( $ability, $input ) {
-		$input_schema = $ability->get_input_schema();
-
-		if ( empty( $input_schema ) ) {
-			return true;
-		}
-
-		$validation_result = rest_validate_value_from_schema( $input, $input_schema );
-		if ( is_wp_error( $validation_result ) ) {
-			return new \WP_Error(
-				'rest_invalid_param',
-				sprintf(
-					/* translators: %s: error message */
-					__( 'Invalid input parameters: %s' ),
-					$validation_result->get_error_message()
-				),
-				array( 'status' => 400 )
-			);
-		}
-
-		return true;
-	}
-
-	/**
-	 * Validates output data against the ability's output schema.
-	 *
-	 * @since 0.1.0
-	 *
-	 * @param \WP_Ability $ability The ability object.
-	 * @param mixed       $output  The output data to validate.
-	 * @return true|\WP_Error True if validation passes, WP_Error object on failure.
-	 */
-	private function validate_output( $ability, $output ) {
-		$output_schema = $ability->get_output_schema();
-
-		if ( empty( $output_schema ) ) {
-			return true;
-		}
-
-		$validation_result = rest_validate_value_from_schema( $output, $output_schema );
-		if ( is_wp_error( $validation_result ) ) {
-			return new \WP_Error(
-				'rest_invalid_response',
-				sprintf(
-					/* translators: %s: error message */
-					__( 'Invalid response from ability: %s' ),
-					$validation_result->get_error_message()
-				),
-				array( 'status' => 500 )
 			);
 		}
 

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -182,8 +182,6 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 
 		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_properties );
 
-		$this->setExpectedIncorrectUsage( 'WP_Ability::execute' );
-
 		$actual = $result->execute(
 			array(
 				'a'       => 2,
@@ -196,7 +194,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 			$actual,
 			'Execution should fail due to input not matching schema'
 		);
-		$this->assertEquals( 'ability_invalid_permissions', $actual->get_error_code() );
+		$this->assertEquals( 'ability_invalid_input', $actual->get_error_code() );
 	}
 
 	/**
@@ -220,7 +218,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 			$actual,
 			'Execution should fail due to output not matching schema',
 		);
-		$this->assertEquals( 'rest_invalid_type', $actual->get_error_code() );
+		$this->assertEquals( 'ability_invalid_output', $actual->get_error_code() );
 	}
 
 	/**
@@ -243,7 +241,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 			$actual,
 			'Permission check should fail due to input not matching schema'
 		);
-		$this->assertEquals( 'rest_additional_properties_forbidden', $actual->get_error_code() );
+		$this->assertEquals( 'ability_invalid_input', $actual->get_error_code() );
 	}
 
 	/**

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -192,9 +192,13 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 
 		$this->assertWPError(
 			$actual,
-			'Execution should fail due to input not matching schema'
+			'Execution should fail due to input not matching schema.'
 		);
-		$this->assertEquals( 'ability_invalid_input', $actual->get_error_code() );
+		$this->assertSame( 'ability_invalid_input', $actual->get_error_code() );
+		$this->assertSame(
+			'Ability "test/add-numbers" has invalid input. Reason: unknown is not a valid property of Object.',
+			$actual->get_error_message()
+		);
 	}
 
 	/**
@@ -216,9 +220,13 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 		);
 		$this->assertWPError(
 			$actual,
-			'Execution should fail due to output not matching schema',
+			'Execution should fail due to output not matching schema.',
 		);
-		$this->assertEquals( 'ability_invalid_output', $actual->get_error_code() );
+		$this->assertSame( 'ability_invalid_output', $actual->get_error_code() );
+		$this->assertSame(
+			'Ability "test/add-numbers" has invalid output. Reason: output is not of type number.',
+			$actual->get_error_message()
+		);
 	}
 
 	/**
@@ -239,9 +247,13 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 
 		$this->assertWPError(
 			$actual,
-			'Permission check should fail due to input not matching schema'
+			'Permission check should fail due to input not matching schema.'
 		);
-		$this->assertEquals( 'ability_invalid_input', $actual->get_error_code() );
+		$this->assertSame( 'ability_invalid_input', $actual->get_error_code() );
+		$this->assertSame(
+			'Ability "test/add-numbers" has invalid input. Reason: unknown is not a valid property of Object.',
+			$actual->get_error_message()
+		);
 	}
 
 	/**

--- a/tests/unit/rest-api/wpRestAbilitiesRunController.php
+++ b/tests/unit/rest-api/wpRestAbilitiesRunController.php
@@ -339,7 +339,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 
 		$this->assertEquals( 405, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'rest_invalid_method', $data['code'] );
+		$this->assertEquals( 'rest_ability_invalid_method', $data['code'] );
 		$this->assertStringContainsString( 'Tool abilities require POST', $data['message'] );
 	}
 
@@ -356,7 +356,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 
 		$this->assertEquals( 405, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'rest_invalid_method', $data['code'] );
+		$this->assertEquals( 'rest_ability_invalid_method', $data['code'] );
 		$this->assertStringContainsString( 'Resource abilities require GET', $data['message'] );
 	}
 
@@ -376,7 +376,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		$this->assertEquals( 500, $response->get_status() );
 		$data = $response->get_data();
 
-		$this->assertEquals( 'rest_invalid_type', $data['code'] );
+		$this->assertEquals( 'ability_invalid_output', $data['code'] );
 		$this->assertStringContainsString( 'is not of type number.', $data['message'] );
 	}
 
@@ -403,7 +403,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 
 		$this->assertEquals( 403, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'rest_cannot_execute', $data['code'] );
+		$this->assertEquals( 'rest_ability_cannot_execute', $data['code'] );
 	}
 
 	/**
@@ -621,7 +621,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		// Should return error when output validation fails
 		$this->assertEquals( 500, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'rest_property_required', $data['code'] );
+		$this->assertEquals( 'ability_invalid_output', $data['code'] );
 	}
 
 	/**
@@ -661,7 +661,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		// Should return error when input validation fails.
 		$this->assertEquals( 400, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'rest_invalid_param', $data['code'] );
+		$this->assertEquals( 'ability_invalid_input', $data['code'] );
 	}
 
 	/**
@@ -937,7 +937,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		// Tool abilities should only accept POST, so these should return 405
 		$this->assertEquals( 405, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'rest_invalid_method', $data['code'] );
+		$this->assertEquals( 'rest_ability_invalid_method', $data['code'] );
 	}
 
 	/**

--- a/tests/unit/rest-api/wpRestAbilitiesRunController.php
+++ b/tests/unit/rest-api/wpRestAbilitiesRunController.php
@@ -337,10 +337,10 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/abilities/test/open-tool/run' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertEquals( 405, $response->get_status() );
+		$this->assertSame( 405, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'rest_ability_invalid_method', $data['code'] );
-		$this->assertStringContainsString( 'Tool abilities require POST', $data['message'] );
+		$this->assertSame( 'rest_ability_invalid_method', $data['code'] );
+		$this->assertSame( 'Tool abilities require POST method.', $data['message'] );
 	}
 
 	/**
@@ -354,10 +354,10 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 
 		$response = $this->server->dispatch( $request );
 
-		$this->assertEquals( 405, $response->get_status() );
+		$this->assertSame( 405, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'rest_ability_invalid_method', $data['code'] );
-		$this->assertStringContainsString( 'Resource abilities require GET', $data['message'] );
+		$this->assertSame( 'rest_ability_invalid_method', $data['code'] );
+		$this->assertSame( 'Resource abilities require GET method.', $data['message'] );
 	}
 
 
@@ -373,11 +373,13 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 
 		$response = $this->server->dispatch( $request );
 
-		$this->assertEquals( 500, $response->get_status() );
+		$this->assertSame( 500, $response->get_status() );
 		$data = $response->get_data();
-
-		$this->assertEquals( 'ability_invalid_output', $data['code'] );
-		$this->assertStringContainsString( 'is not of type number.', $data['message'] );
+		$this->assertSame( 'ability_invalid_output', $data['code'] );
+		$this->assertSame(
+			'Ability "test/invalid-output" has invalid output. Reason: output is not of type number.',
+			$data['message']
+		);
 	}
 
 	/**
@@ -401,9 +403,10 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 
 		$response = $this->server->dispatch( $request );
 
-		$this->assertEquals( 403, $response->get_status() );
+		$this->assertSame( 403, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'rest_ability_cannot_execute', $data['code'] );
+		$this->assertSame( 'rest_ability_cannot_execute', $data['code'] );
+		$this->assertSame( 'Sorry, you are not allowed to execute this ability.', $data['message'] );
 	}
 
 	/**
@@ -618,10 +621,14 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 
 		$response = $this->server->dispatch( $request );
 
-		// Should return error when output validation fails
-		$this->assertEquals( 500, $response->get_status() );
+		// Should return error when output validation fails.
+		$this->assertSame( 500, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'ability_invalid_output', $data['code'] );
+		$this->assertSame( 'ability_invalid_output', $data['code'] );
+		$this->assertSame(
+			'Ability "test/strict-output" has invalid output. Reason: status is a required property of output.',
+			$data['message']
+		);
 	}
 
 	/**
@@ -659,9 +666,13 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 
 		// Should return error when input validation fails.
-		$this->assertEquals( 400, $response->get_status() );
+		$this->assertSame( 400, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'ability_invalid_input', $data['code'] );
+		$this->assertSame( 'ability_invalid_input', $data['code'] );
+		$this->assertSame(
+			'Ability "test/strict-input" has invalid input. Reason: required_field is a required property of input.',
+			$data['message']
+		);
 	}
 
 	/**
@@ -934,10 +945,11 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		$request  = new WP_REST_Request( $method, '/wp/v2/abilities/test/method-test/run' );
 		$response = $this->server->dispatch( $request );
 
-		// Tool abilities should only accept POST, so these should return 405
-		$this->assertEquals( 405, $response->get_status() );
+		// Tool abilities should only accept POST, so these should return 405.
+		$this->assertSame( 405, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'rest_ability_invalid_method', $data['code'] );
+		$this->assertSame( 'rest_ability_invalid_method', $data['code'] );
+		$this->assertSame( 'Tool abilities require POST method.', $data['message'] );
 	}
 
 	/**


### PR DESCRIPTION
- Closes https://github.com/WordPress/abilities-api/issues/14.
- Follow-up for https://github.com/WordPress/abilities-api/pull/23

It addresses the following refactoring:

> Consider updating WP_Ability to return WP_Error for better error handling which would then simplify and unify the implementation in REST API controller. 

This PR standardizes error handling in the REST API abilities run controller by introducing consistent error codes for different types of validation failures and moving validation logic from the REST controller into the core WP_Ability class.

## Testing

Run `npm run test:php` and make sure all tests pass.