### PR TITLE
Documentation: Include specific nvm version needed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,8 @@ You can use Docker and the `wp-env` tool to set up a local development environme
 2. Change into the project folder and install the development dependencies:
 
    ```bash
-   ## Install Node.js 20.10.0 or higher if you don't have it
-   nvm install 20 && nvm use
+   ## If you're using nvm, make sure to use the correct Node.js version:
+   nvm install && nvm use
 
    ## Then install the NPM dependencies:
    npm install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,8 @@ You can use Docker and the `wp-env` tool to set up a local development environme
 2. Change into the project folder and install the development dependencies:
 
    ```bash
-   ## If you're using NVM, make sure to use the correct Node.js version:
-   nvm use
+   ## Install Node.js 20.10.0 or higher if you don't have it
+   nvm install 20 && nvm use
 
    ## Then install the NPM dependencies:
    npm install


### PR DESCRIPTION
**Current issue**: The nvm use command will fail if Node.js 20.10.0+ isn't already installed, causing setup errors for new contributors.

**Solution**: Specify the minimum version requirement and provide a single command that handles both installation and activation.

Issue: https://github.com/WordPress/abilities-api/issues/32