### PR TITLE
Chore: Configure the composer package for publishing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,6 @@
 
 # Tests and test fixtures
 /tests/ export-ignore
-/tests/** export-ignore
 
 # PHP unit / static analysis configs.
 /phpcs.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,45 @@
+# Automatically normalize line endings.
+* text=auto
+
+# Files and directories to exclude from the generated archive (export-ignore).
+# These will be omitted from GitHub/Packagist ZIP archives to keep packages small.
+
+# Tests and test fixtures
+/tests/ export-ignore
+/tests/** export-ignore
+
+# PHP unit / static analysis configs.
+/phpcs.xml.dist export-ignore
+/phpstan.neon.dist export-ignore
+/phpunit.xml.dist export-ignore
+
+# Continuous Integration configs.
+/.github/ export-ignore
+/.github/** export-ignore
+
+# Node and build artifacts.
+node_modules/ export-ignore
+node_modules/** export-ignore
+package.json export-ignore
+package-lock.json export-ignore
+
+# Composer/vendor and dev tooling.
+/vendor/ export-ignore
+/vendor/** export-ignore
+/composer.lock export-ignore
+
+# Don't include the dotfiles for distribution.
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+.gitignore export-ignore
+.gitkeep export-ignore
+/.nvmrc export-ignore
+/.prettierignore export-ignore
+/.prettierrc.js export-ignore
+/.wp-env.json export-ignore
+
+# Mark docs as documentation for GitHub Linguist.
+/docs/** linguist-documentation
+/CONTRIBUTING.md linguist-documentation
+/LICENSE.md linguist-documentation
+/README.md linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -15,31 +15,17 @@
 
 # Continuous Integration configs.
 /.github/ export-ignore
-/.github/** export-ignore
 
 # Node and build artifacts.
-node_modules/ export-ignore
-node_modules/** export-ignore
 package.json export-ignore
 package-lock.json export-ignore
-
-# Composer/vendor and dev tooling.
-/vendor/ export-ignore
-/vendor/** export-ignore
 /composer.lock export-ignore
 
 # Don't include the dotfiles for distribution.
-/.editorconfig export-ignore
-/.gitattributes export-ignore
-.gitignore export-ignore
-.gitkeep export-ignore
-/.nvmrc export-ignore
-/.prettierignore export-ignore
-/.prettierrc.js export-ignore
-/.wp-env.json export-ignore
+/.* export-ignore
 
 # Mark docs as documentation for GitHub Linguist.
-/docs/** linguist-documentation
-/CONTRIBUTING.md linguist-documentation
+/docs/ linguist-documentation export-ignore
+/CONTRIBUTING.md linguist-documentation export-ignore
 /LICENSE.md linguist-documentation
 /README.md linguist-documentation

--- a/abilities-api.php
+++ b/abilities-api.php
@@ -26,17 +26,8 @@
  */
 define( 'WP_ABILITIES_API_DIR', plugin_dir_path( __FILE__ ) );
 
-/**
- * Prefer Composer autoloader when available. If present, it will load
- * `includes/bootstrap.php` (registered in composer.json) which makes the
- * procedural functions and classes available. Otherwise fall back to the
- * local includes bootstrap to keep compatibility with non-Composer installs.
- */
-if ( file_exists( WP_ABILITIES_API_DIR . 'vendor/autoload.php' ) ) {
-	require_once WP_ABILITIES_API_DIR . 'vendor/autoload.php';
-} else {
-	require_once WP_ABILITIES_API_DIR . 'includes/bootstrap.php';
-}
+
+require_once WP_ABILITIES_API_DIR . 'includes/bootstrap.php';
 
 if ( function_exists( 'add_action' ) ) {
 	add_action( 'rest_api_init', array( 'WP_REST_Abilities_Init', 'register_routes' ) );

--- a/abilities-api.php
+++ b/abilities-api.php
@@ -27,26 +27,17 @@
 define( 'WP_ABILITIES_API_DIR', plugin_dir_path( __FILE__ ) );
 
 /**
- * Version of the plugin.
+ * Prefer Composer autoloader when available. If present, it will load
+ * `includes/bootstrap.php` (registered in composer.json) which makes the
+ * procedural functions and classes available. Otherwise fall back to the
+ * local includes bootstrap to keep compatibility with non-Composer installs.
  */
-define( 'WP_ABILITIES_API_VERSION', '0.1.0' );
+if ( file_exists( WP_ABILITIES_API_DIR . 'vendor/autoload.php' ) ) {
+	require_once WP_ABILITIES_API_DIR . 'vendor/autoload.php';
+} else {
+	require_once WP_ABILITIES_API_DIR . 'includes/bootstrap.php';
+}
 
-/**
- * First the WP_Ability class that users can extend.
- */
-require_once WP_ABILITIES_API_DIR . 'includes/abilities-api/class-wp-ability.php';
-
-/**
- * Then the WP_Abilities_Registry class that manages the abilities.
- */
-require_once WP_ABILITIES_API_DIR . 'includes/abilities-api/class-wp-abilities-registry.php';
-
-/**
- * Then the public access functions that users can use to interact with the abilities.
- */
-require_once WP_ABILITIES_API_DIR . 'includes/abilities-api.php';
-
-/**
- * Initialize REST API controllers.
- */
-require_once WP_ABILITIES_API_DIR . 'includes/rest-api/class-wp-rest-abilities-init.php';
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'rest_api_init', array( 'WP_REST_Abilities_Init', 'register_routes' ) );
+}

--- a/composer.json
+++ b/composer.json
@@ -1,33 +1,44 @@
 {
 	"name": "wordpress/abilities-api",
-	"description": "AI Abilities for WordPress",
+	"description": "AI Abilities for WordPress.",
 	"license": "GPL-2.0-or-later",
 	"type": "wordpress-plugin",
-	"version": "0.1.0",
 	"keywords": [
 		"ai",
+		"api",
 		"llm",
 		"abilities",
-		"abilities-api",
 		"wordpress"
 	],
-	"homepage": "https://github.com/WordPress/abilities-api/issues",
+	"authors": [
+		{
+			"name": "WordPress AI Team",
+			"homepage": "https://make.wordpress.org/ai/"
+		}
+	],
+	"homepage": "https://github.com/WordPress/abilities-api",
 	"support": {
-		"issues": "https://github.com/WordPress/abilities-api/issues"
+		"issues": "https://github.com/WordPress/abilities-api/issues",
+		"source": "https://github.com/WordPress/abilities-api"
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"autoload": {
+		"files": [
+			"includes/bootstrap.php"
+		]
 	},
 	"config": {
-		"sort-packages": true,
-		"platform": {
-			"php": "7.4"
-		},
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true,
 			"phpstan/extension-installer": true,
 			"composer/installers": true
-		}
+		},
+		"platform": {
+			"php": "7.4"
+		},
+		"sort-packages": true
 	},
-	"minimum-stability": "dev",
-	"prefer-stable": true,
 	"repositories": [
 		{
 			"type": "composer",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "wordpress/abilities-api",
 	"description": "AI Abilities for WordPress.",
 	"license": "GPL-2.0-or-later",
-	"type": "wordpress-plugin",
+	"type": "library",
 	"keywords": [
 		"ai",
 		"api",

--- a/composer.lock
+++ b/composer.lock
@@ -5169,9 +5169,9 @@
     "platform": {
         "php": "^7.4 | ^8"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/includes/abilities-api.php
+++ b/includes/abilities-api.php
@@ -5,7 +5,7 @@
  * Defines functions for managing abilities in WordPress.
  *
  * @package WordPress
- * @subpackage Abilities API
+ * @subpackage Abilities_API
  * @since 0.1.0
  *
  * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -1,14 +1,17 @@
 <?php
 /**
- * Abilities API - Composer bootstrap
+ * Bootstraps the Abilities API classes and global functions.
  *
  * This file is autoloaded by Composer when the package is installed via the
  * "files" autoload mechanism. It ensures the procedural functions defined in
  * `includes/abilities-api.php` are available without requiring namespaces.
  *
- * Keep this file simple and side-effect free except for requiring the functions
- * file.
+ * @package WordPress
+ * @subpackage Abilities_API
+ * @since 0.1.0
  */
+
+declare( strict_types = 1 );
 
 // Version of the plugin.
 if ( ! defined( 'WP_ABILITIES_API_VERSION' ) ) {

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Abilities API - Composer bootstrap
+ *
+ * This file is autoloaded by Composer when the package is installed via the
+ * "files" autoload mechanism. It ensures the procedural functions defined in
+ * `includes/abilities-api.php` are available without requiring namespaces.
+ *
+ * Keep this file simple and side-effect free except for requiring the functions
+ * file.
+ */
+
+// Load core classes if they are not already defined (for non-Composer installs or direct includes).
+if ( ! class_exists( 'WP_Ability' ) ) {
+	require_once __DIR__ . '/abilities-api/class-wp-ability.php';
+}
+
+if ( ! class_exists( 'WP_Abilities_Registry' ) ) {
+	require_once __DIR__ . '/abilities-api/class-wp-abilities-registry.php';
+}
+
+// Ensure procedural functions are available.
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	require_once __DIR__ . '/abilities-api.php';
+}
+
+// Load REST API init class for plugin bootstrap.
+if ( ! class_exists( 'WP_REST_Abilities_Init' ) ) {
+	require_once __DIR__ . '/rest-api/class-wp-rest-abilities-init.php';
+}

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -10,16 +10,20 @@
  * file.
  */
 
+// Version of the plugin.
+if ( ! defined( 'WP_ABILITIES_API_VERSION' ) ) {
+	define( 'WP_ABILITIES_API_VERSION', '0.1.0' );
+}
+
 // Load core classes if they are not already defined (for non-Composer installs or direct includes).
 if ( ! class_exists( 'WP_Ability' ) ) {
 	require_once __DIR__ . '/abilities-api/class-wp-ability.php';
 }
-
 if ( ! class_exists( 'WP_Abilities_Registry' ) ) {
 	require_once __DIR__ . '/abilities-api/class-wp-abilities-registry.php';
 }
 
-// Ensure procedural functions are available.
+// Ensure procedural functions are available, too.
 if ( ! function_exists( 'wp_register_ability' ) ) {
 	require_once __DIR__ . '/abilities-api.php';
 }

--- a/includes/rest-api/class-wp-rest-abilities-init.php
+++ b/includes/rest-api/class-wp-rest-abilities-init.php
@@ -31,5 +31,3 @@ class WP_REST_Abilities_Init {
 		$list_controller->register_routes();
 	}
 }
-
-add_action( 'rest_api_init', array( 'WP_REST_Abilities_Init', 'register_routes' ) );

--- a/includes/rest-api/class-wp-rest-abilities-init.php
+++ b/includes/rest-api/class-wp-rest-abilities-init.php
@@ -2,8 +2,9 @@
 /**
  * REST API initialization for Abilities API.
  *
- * @package abilities-api
- * @since   0.1.0
+ * @package WordPress
+ * @subpackage Abilities_API
+ * @since 0.1.0
  */
 
 declare( strict_types = 1 );

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
@@ -2,8 +2,9 @@
 /**
  * REST API list controller for Abilities API.
  *
- * @package abilities-api
- * @since   0.1.0
+ * @package WordPress
+ * @subpackage Abilities_API
+ * @since 0.1.0
  */
 
 declare( strict_types = 1 );

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
@@ -2,8 +2,9 @@
 /**
  * REST API run controller for Abilities API.
  *
- * @package abilities-api
- * @since   0.1.0
+ * @package WordPress
+ * @subpackage Abilities_API
+ * @since 0.1.0
  */
 
 declare( strict_types = 1 );


### PR DESCRIPTION
- Closes https://github.com/WordPress/abilities-api/issues/13.

Prepare the composer package for publication and consumption by WordPress plugins.

For complete transparency, I reused some of the configurations from:
- https://github.com/WordPress/php-ai-client/blob/trunk/composer.json
- https://github.com/WordPress/php-ai-client/blob/trunk/.gitattributes
- https://github.com/WordPress/gutenberg/blob/trunk/.gitattributes

I also used AI (GitHub Copilot coding agent) extensively to configure everything so it works both as a WP plugin and shares only `includes` through Composer. I avoided using namespaces to keep things simplified and used `autoload.files` to bootstrap all necessary files.

## Testing

Some checks that I executed

### Validate composer config

```bash
composer validate --no-check-publish
```

Result contained deprecation notices and a success message:

```
./composer.json is valid
```

### Files included in the git archive

```bash
echo "Total tracked files:" && git ls-files | wc -l && echo "\nFiles in git archive (respecting .gitattributes export-ignore):" && git archive --format=tar HEAD | tar -tf - | wc -l && echo "\nFiles excluded from archive (tracked but export-ignored):" && comm -23 <(git ls-files | sort) <(git archive --format=tar HEAD | tar -tf - | sort) | sed -n '1,200p' && echo "\nFiles explicitly in archive (sample):" && git archive --format=tar HEAD | tar -tf - | sed -n '1,200p'
```

Result

```
Total tracked files:
      40

Files in git archive (respecting .gitattributes export-ignore):
      22

Files excluded from archive (tracked but export-ignored):
.editorconfig
.gitattributes
.github/workflows/copilot-setup-steps.yml
.github/workflows/release.yml
.github/workflows/test.yml
.gitignore
.nvmrc
.prettierignore
.prettierrc.js
.wordpress-org/.gitkeep
.wp-env.json
composer.lock
package-lock.json
package.json
phpcs.xml.dist
phpstan.neon.dist
phpunit.xml.dist
tests/_output/.gitkeep
tests/bootstrap.php
tests/unit/abilities-api/wpAbilitiesRegistry.php
tests/unit/abilities-api/wpRegisterAbility.php
tests/unit/rest-api/wpRestAbilitiesInit.php
tests/unit/rest-api/wpRestAbilitiesListController.php
tests/unit/rest-api/wpRestAbilitiesRunController.php

Files explicitly in archive (sample):
.wordpress-org/
CONTRIBUTING.md
LICENSE.md
README.md
abilities-api.php
composer.json
docs/
docs/1.intro.md
docs/2.getting-started.md
docs/3.registering-abilities.md
docs/4.using-abilities.md
includes/
includes/abilities-api.php
includes/abilities-api/
includes/abilities-api/class-wp-abilities-registry.php
includes/abilities-api/class-wp-ability.php
includes/bootstrap.php
includes/rest-api/
includes/rest-api/class-wp-rest-abilities-init.php
includes/rest-api/endpoints/
includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
```