### PR TITLE
Remove `ignoreErrors` from PHPStan

### DIFF
--- a/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
@@ -89,7 +89,7 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param \WP_REST_Request $request Full details about the request.
+	 * @param \WP_REST_Request<array<string,mixed>> $request Full details about the request.
 	 * @return \WP_REST_Response Response object on success.
 	 */
 	public function get_items( $request ) {
@@ -144,7 +144,7 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param \WP_REST_Request $request Full details about the request.
+	 * @param \WP_REST_Request<array<string,mixed>> $request Full details about the request.
 	 * @return \WP_REST_Response|\WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_item( $request ) {
@@ -167,7 +167,7 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param \WP_REST_Request $request Full details about the request.
+	 * @param \WP_REST_Request<array<string,mixed>> $request Full details about the request.
 	 * @return bool True if the request has read access.
 	 */
 	public function get_permissions_check( $request ) {
@@ -179,8 +179,8 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param \WP_Ability      $ability The ability object.
-	 * @param \WP_REST_Request $request Request object.
+	 * @param \WP_Ability                           $ability The ability object.
+	 * @param \WP_REST_Request<array<string,mixed>> $request Request object.
 	 * @return \WP_REST_Response Response object.
 	 */
 	public function prepare_item_for_response( $ability, $request ) {

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
@@ -75,7 +75,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param \WP_REST_Request $request Full details about the request.
+	 * @param \WP_REST_Request<array<string,mixed>> $request Full details about the request.
 	 * @return \WP_REST_Response|\WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function run_ability_with_method_check( $request ) {
@@ -118,7 +118,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param \WP_REST_Request $request Full details about the request.
+	 * @param \WP_REST_Request<array<string,mixed>> $request Full details about the request.
 	 * @return \WP_REST_Response|\WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function run_ability( $request ) {
@@ -148,7 +148,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param \WP_REST_Request $request Full details about the request.
+	 * @param \WP_REST_Request<array<string,mixed>> $request Full details about the request.
 	 * @return true|\WP_Error True if the request has execution permission, WP_Error object otherwise.
 	 */
 	public function run_ability_permissions_check( $request ) {
@@ -178,7 +178,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param \WP_REST_Request $request The request object.
+	 * @param \WP_REST_Request<array<string,mixed>> $request The request object.
 	 * @return array<string, mixed> The input parameters.
 	 */
 	private function get_input_from_request( $request ) {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -29,14 +29,3 @@ parameters:
 			analyseAndScan:
 				- node_modules (?)
 
-		# Ignore specific errors
-		ignoreErrors:
-			# WP_REST_Request is not actually a generic class in WordPress core.
-			# PHPStan's WordPress stubs appear to define it as generic for type checking,
-			# but WordPress itself doesn't use generics. This seems to be an incompatibility
-			# between static analysis tools and WordPress's actual implementation.
-			-
-				message: '#has parameter \$request with generic class WP_REST_Request but does not specify its types#'
-				paths:
-					- includes/rest-api/**/*.php
-


### PR DESCRIPTION
- Part of https://github.com/WordPress/abilities-api/issues/13.

I audited `ignoreErrors` added to PHPStan (https://github.com/WordPress/abilities-api/pull/6#discussion_r2274466039). I decided to remove it and fix the PHPDoc to make PHPStan happy.