### PR TITLE
Updated Inline Documentation Order

### DIFF
--- a/includes/abilities-api/class-wp-abilities-registry.php
+++ b/includes/abilities-api/class-wp-abilities-registry.php
@@ -39,9 +39,9 @@ final class WP_Abilities_Registry {
 	 *
 	 * Do not use this method directly. Instead, use the `wp_register_ability()` function.
 	 *
-	 * @see wp_register_ability()
-	 *
 	 * @since 0.1.0
+	 *
+	 * @see wp_register_ability()
 	 *
 	 * @param string              $name       The name of the ability. The name must be a string containing a namespace
 	 *                                        prefix, i.e. `my-plugin/my-ability`. It can only contain lowercase
@@ -175,9 +175,9 @@ final class WP_Abilities_Registry {
 	 *
 	 * Do not use this method directly. Instead, use the `wp_unregister_ability()` function.
 	 *
-	 * @see wp_unregister_ability()
-	 *
 	 * @since 0.1.0
+	 *
+	 * @see wp_unregister_ability()
 	 *
 	 * @param string $name The name of the registered ability, with its namespace.
 	 * @return ?\WP_Ability The unregistered ability instance on success, null on failure.
@@ -204,9 +204,9 @@ final class WP_Abilities_Registry {
 	 *
 	 * Do not use this method directly. Instead, use the `wp_get_abilities()` function.
 	 *
-	 * @see wp_get_abilities()
-	 *
 	 * @since 0.1.0
+	 *
+	 * @see wp_get_abilities()
 	 *
 	 * @return \WP_Ability[] The array of registered abilities.
 	 */
@@ -231,9 +231,9 @@ final class WP_Abilities_Registry {
 	 *
 	 * Do not use this method directly. Instead, use the `wp_get_ability()` function.
 	 *
-	 * @see wp_get_ability()
-	 *
 	 * @since 0.1.0
+	 *
+	 * @see wp_get_ability()
 	 *
 	 * @param string $name The name of the registered ability, with its namespace.
 	 * @return ?\WP_Ability The registered ability instance, or null if it is not registered.

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -92,9 +92,9 @@ class WP_Ability {
 	 *
 	 * @access private
 	 *
-	 * @see wp_register_ability()
-	 *
 	 * @since 0.1.0
+	 *
+	 * @see wp_register_ability()
 	 *
 	 * @param string              $name       The name of the ability, with its namespace.
 	 * @param array<string,mixed> $properties An associative array of properties for the ability. This should


### PR DESCRIPTION
Updated Inline Documentation Order. (Added `@since` tag before `@see` tag according to [PHP Documentation Standards
](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/)

**Files:** 
- `includes/abilities-api/class-wp-abilities-registry.php`
- `includes/abilities-api/class-wp-ability.php`