### PR TITLE
dev!: handle property registration inside WP_Ability

### DIFF
--- a/includes/abilities-api/class-wp-abilities-registry.php
+++ b/includes/abilities-api/class-wp-abilities-registry.php
@@ -85,69 +85,7 @@ final class WP_Abilities_Registry {
 			return null;
 		}
 
-		if ( empty( $properties['label'] ) || ! is_string( $properties['label'] ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				esc_html__( 'The ability properties must contain a `label` string.' ),
-				'0.1.0'
-			);
-			return null;
-		}
-
-		if ( empty( $properties['description'] ) || ! is_string( $properties['description'] ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				esc_html__( 'The ability properties must contain a `description` string.' ),
-				'0.1.0'
-			);
-			return null;
-		}
-
-		if ( isset( $properties['input_schema'] ) && ! is_array( $properties['input_schema'] ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				esc_html__( 'The ability properties should provide a valid `input_schema` definition.' ),
-				'0.1.0'
-			);
-			return null;
-		}
-
-		if ( isset( $properties['output_schema'] ) && ! is_array( $properties['output_schema'] ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				esc_html__( 'The ability properties should provide a valid `output_schema` definition.' ),
-				'0.1.0'
-			);
-			return null;
-		}
-
-		if ( empty( $properties['execute_callback'] ) || ! is_callable( $properties['execute_callback'] ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				esc_html__( 'The ability properties must contain a valid `execute_callback` function.' ),
-				'0.1.0'
-			);
-			return null;
-		}
-
-		if ( isset( $properties['permission_callback'] ) && ! is_callable( $properties['permission_callback'] ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				esc_html__( 'The ability properties should provide a valid `permission_callback` function.' ),
-				'0.1.0'
-			);
-			return null;
-		}
-
-		if ( isset( $properties['meta'] ) && ! is_array( $properties['meta'] ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				esc_html__( 'The ability properties should provide a valid `meta` array.' ),
-				'0.1.0'
-			);
-			return null;
-		}
-
+		// The class is only used to instantiate the ability, and is not a property of the ability itself.
 		if ( isset( $properties['ability_class'] ) && ! is_a( $properties['ability_class'], WP_Ability::class, true ) ) {
 			_doing_it_wrong(
 				__METHOD__,
@@ -156,15 +94,23 @@ final class WP_Abilities_Registry {
 			);
 			return null;
 		}
-
-		// The class is only used to instantiate the ability, and is not a property of the ability itself.
 		$ability_class = $properties['ability_class'] ?? WP_Ability::class;
 		unset( $properties['ability_class'] );
 
-		$ability = new $ability_class(
-			$name,
-			$properties
-		);
+		try {
+			// WP_Ability::validate_properties() will throw an exception if the properties are invalid.
+			$ability = new $ability_class(
+				$name,
+				$properties
+			);
+		} catch ( \InvalidArgumentException $e ) {
+			_doing_it_wrong(
+				__METHOD__,
+				esc_html( $e->getMessage() ),
+				'0.1.0'
+			);
+			return null;
+		}
 
 		$this->registered_abilities[ $name ] = $ability;
 		return $ability;

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -100,20 +100,11 @@ class WP_Ability {
 	 * @param array<string,mixed> $properties An associative array of properties for the ability. This should
 	 *                                        include `label`, `description`, `input_schema`, `output_schema`,
 	 *                                        `execute_callback`, `permission_callback`, and `meta`.
-	 *
-	 * @phpstan-param array{
-	 *   label: string,
-	 *   description: string,
-	 *   input_schema?: array<string,mixed>,
-	 *   output_schema?: array<string,mixed>,
-	 *   execute_callback: callable( array<string,mixed> $input): (mixed|\WP_Error),
-	 *   permission_callback?: ?callable( array<string,mixed> $input ): (bool|\WP_Error),
-	 *   meta?: array<string,mixed>,
-	 *   ...<string, mixed>,
-	 * } $properties
 	 */
 	public function __construct( string $name, array $properties ) {
 		$this->name = $name;
+
+		$this->validate_properties( $properties );
 
 		foreach ( $properties as $property_name => $property_value ) {
 			if ( ! property_exists( $this, $property_name ) ) {
@@ -200,6 +191,76 @@ class WP_Ability {
 	 */
 	public function get_meta(): array {
 		return $this->meta;
+	}
+
+	/**
+	 * Validates the properties used to instantiate the ability.
+	 *
+	 * Errors are thrown as exceptions instead of \WP_Errors to allow for simpler handling and overloading. They are then
+	 * caught and converted to a WP_Error when by WP_Abilities_Registry::register().
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @see WP_Abilities_Registry::register()
+	 *
+	 * @param array<string,mixed> $properties An associative array of properties to validate.
+	 *
+	 * @return void
+	 * @throws \InvalidArgumentException if the properties are invalid.
+	 *
+	 * @phpstan-assert array{
+	 *   label: string,
+	 *   description: string,
+	 *   input_schema?: array<string,mixed>,
+	 *   output_schema?: array<string,mixed>,
+	 *   execute_callback: callable( array<string,mixed> $input): (mixed|\WP_Error),
+	 *   permission_callback?: ?callable( array<string,mixed> $input ): (bool|\WP_Error),
+	 *   meta?: array<string,mixed>,
+	 *   ...<string, mixed>,
+	 * } $properties
+	 */
+	protected function validate_properties( array $properties ) {
+		if ( empty( $properties['label'] ) || ! is_string( $properties['label'] ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'The ability properties must contain a `label` string.' )
+			);
+		}
+
+		if ( empty( $properties['description'] ) || ! is_string( $properties['description'] ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'The ability properties must contain a `description` string.' )
+			);
+		}
+
+		if ( isset( $properties['input_schema'] ) && ! is_array( $properties['input_schema'] ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'The ability properties should provide a valid `input_schema` definition.' )
+			);
+		}
+
+		if ( isset( $properties['output_schema'] ) && ! is_array( $properties['output_schema'] ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'The ability properties should provide a valid `output_schema` definition.' )
+			);
+		}
+
+		if ( empty( $properties['execute_callback'] ) || ! is_callable( $properties['execute_callback'] ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'The ability properties must contain a valid `execute_callback` function.' )
+			);
+		}
+
+		if ( isset( $properties['permission_callback'] ) && ! is_callable( $properties['permission_callback'] ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'The ability properties should provide a valid `permission_callback` function.' )
+			);
+		}
+
+		if ( isset( $properties['meta'] ) && ! is_array( $properties['meta'] ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'The ability properties should provide a valid `meta` array.' )
+			);
+		}
 	}
 
 	/**

--- a/tests/unit/abilities-api/wpAbilitiesRegistry.php
+++ b/tests/unit/abilities-api/wpAbilitiesRegistry.php
@@ -383,4 +383,22 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 		$this->assertSame( $ability_two_name, $result[ $ability_two_name ]->get_name() );
 		$this->assertSame( $ability_three_name, $result[ $ability_three_name ]->get_name() );
 	}
+
+	/**
+	 * Direct instantiation of WP_Ability with invalid properties should throw an exception.
+	 *
+	 * @covers WP_Ability::__construct
+	 * @covers WP_Ability::validate_properties
+	 */
+	public function test_wp_ability_invalid_properties_throws_exception() {
+		$this->expectException( \InvalidArgumentException::class );
+		new WP_Ability(
+			'test/invalid',
+			array(
+				'label'            => '',
+				'description'      => '',
+				'execute_callback' => null,
+			)
+		);
+	}
 }


### PR DESCRIPTION
## What

Refactors `WP_Ability` to validate its own properties.

## How 

`WP_Ability::validate_properties()` throws an exception, which is caught and translated into a `_doing_it_wrong()` by `WP_Abilities_API::register()` which was previously handled registration and validation.

More specific implementation notes are in the diff.

## Why

- Fixes #53 

This approach improves separation of concerns and SRP between `WP_Ability` and `WP_Ability_Registry` in a way that also simplifies the DX for users needing to extend the `WP_Ability` class. Instead of needing to shim instantiation to comply or circumvent `WP_Ability_Registry`, developers can overload `WP_Ability::validate_properties()` colocated with the other changes that justify extending the class, or even choose to bypass it entirely in their overloaded constructor.


## Beyond the Scope

- Renaming references of ability `properties` to `args` now that there's no semantic implication from the distinction.
- Auditing the validation logic, error messages, or use of `_doing_it_wrong()` over other flavors of WordPress error handling
- Backfilling WPUnit tests for previously committed validation logic..

