### PR TITLE
Fix REST API initialization for composer package usage

### DIFF
--- a/abilities-api.php
+++ b/abilities-api.php
@@ -28,7 +28,3 @@ define( 'WP_ABILITIES_API_DIR', plugin_dir_path( __FILE__ ) );
 
 
 require_once WP_ABILITIES_API_DIR . 'includes/bootstrap.php';
-
-if ( function_exists( 'add_action' ) ) {
-	add_action( 'rest_api_init', array( 'WP_REST_Abilities_Init', 'register_routes' ) );
-}

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -34,4 +34,9 @@ if ( ! function_exists( 'wp_register_ability' ) ) {
 // Load REST API init class for plugin bootstrap.
 if ( ! class_exists( 'WP_REST_Abilities_Init' ) ) {
 	require_once __DIR__ . '/rest-api/class-wp-rest-abilities-init.php';
+	
+	// Initialize REST API routes when WordPress is available.
+	if ( function_exists( 'add_action' ) ) {
+		add_action( 'rest_api_init', array( 'WP_REST_Abilities_Init', 'register_routes' ) );
+	}
 }

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -13,6 +13,10 @@
 
 declare( strict_types = 1 );
 
+if ( ! defined( 'ABSPATH' ) ) {
+	return; // Not in WordPress context
+}
+
 // Version of the plugin.
 if ( ! defined( 'WP_ABILITIES_API_VERSION' ) ) {
 	define( 'WP_ABILITIES_API_VERSION', '0.1.0' );

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -34,7 +34,7 @@ if ( ! function_exists( 'wp_register_ability' ) ) {
 // Load REST API init class for plugin bootstrap.
 if ( ! class_exists( 'WP_REST_Abilities_Init' ) ) {
 	require_once __DIR__ . '/rest-api/class-wp-rest-abilities-init.php';
-	
+
 	// Initialize REST API routes when WordPress is available.
 	if ( function_exists( 'add_action' ) ) {
 		add_action( 'rest_api_init', array( 'WP_REST_Abilities_Init', 'register_routes' ) );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,7 +34,8 @@ require_once $_test_root . '/includes/functions.php';
 tests_add_filter(
 	'muplugins_loaded',
 	static function (): void {
-		require_once dirname( __DIR__ ) . '/abilities-api.php';
+		// Require ( to bypass require_once ).
+		require dirname( __DIR__ ) . '/includes/bootstrap.php';
 	}
 );
 


### PR DESCRIPTION
## Summary
- Fixes REST API routes not being initialized when abilities-api is used as a composer package
- Moves REST API route registration from plugin file to bootstrap.php to ensure initialization in all cases
- Prevents duplicate registration by placing hook inside class existence check

## Changes
- Moved `rest_api_init` hook registration from `abilities-api.php` to `includes/bootstrap.php`
- Consolidated REST API initialization logic in bootstrap file
- Ensures REST API routes work for both plugin and composer package installations

🤖 Generated with [Claude Code](https://claude.ai/code)