### PR TITLE
Add execute actions to the ability object

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 - **Discuss:** `#core-ai` channel on WordPress Slack.
 - **File issues:** suggestions & use‑cases welcome in this repo.
-- **Prototype:** experiment with the [`wordpress/abilities-api`](https://packagist.org/packages/wordpress/abilities-api) Composer package.
+- **Prototype:** experiment with the [feature plugin](https://github.com/WordPress/abilities-api/releases/latest) or the [`wordpress/abilities-api`](https://packagist.org/packages/wordpress/abilities-api) Composer package.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [Registering Abilities](docs/3.registering-abilities.md)
 - [Using Abilities](docs/4.using-abilities.md)
 - [REST API Reference](docs/5.rest-api.md)
+- [Hooks](docs/6.hooks.md)
 - [Contributing Guidelines](CONTRIBUTING.md)
 
 ## Inspiration
@@ -36,16 +37,16 @@
 | Milestone                           | State       |
 | ----------------------------------- | ----------- |
 | Placeholder repository              | **created** |
-| Spec draft                          | in progress |
-| Prototype plugin & Composer package | in progress |
-| Community feedback (#core‑ai Slack) | planned     |
+| Spec draft                          | **created** |
+| Prototype plugin & Composer package | **created** |
+| Community feedback (#core‑ai Slack) | in progress |
 | Core proposal                       | planned     |
 
 ## How to Get Involved
 
 - **Discuss:** `#core-ai` channel on WordPress Slack.
 - **File issues:** suggestions & use‑cases welcome in this repo.
-- **Prototype:** experiment with the upcoming Composer package once released.
+- **Prototype:** experiment with the [`wordpress/abilities-api`](https://packagist.org/packages/wordpress/abilities-api) Composer package.
 
 ## License
 

--- a/docs/6.hooks.md
+++ b/docs/6.hooks.md
@@ -1,6 +1,6 @@
 # 6. Hooks
 
-The Abilities API provides WordPress action hooks that allow developers to monitor and respond to ability execution events. These hooks enable logging, debugging, analytics, and custom integrations.
+The Abilities API provides [WordPress Action Hooks](https://developer.wordpress.org/apis/hooks/) that allow developers to monitor and respond to ability execution events.
 
 ## Available Actions
 
@@ -47,32 +47,6 @@ do_action( 'after_execute_ability', $ability_name, $input, $result );
 - `$ability_name` (`string`): The namespaced name of the ability that was executed.
 - `$input` (`mixed`): The input data that was passed to the ability.
 - `$result` (`mixed`): The validated result returned by the ability's execution callback.
-
-## When Actions Fire
-
-**`before_execute_ability` fires when:**
-
-- ✅ Permission checks pass.
-- ✅ Input validation succeeds (if input schema is defined).
-- ✅ Just before the execution callback is called.
-
-**`before_execute_ability` does NOT fire when:**
-
-- ❌ Permission checks fail.
-- ❌ Input validation fails.
-
-**`after_execute_ability` fires when:**
-
-- ✅ The execution callback returns successfully (not a `WP_Error`).
-- ✅ Output validation passes (if output schema is defined).
-- ✅ The ability execution completes successfully.
-
-**`after_execute_ability` does NOT fire when:**
-
-- ❌ Permission checks fail.
-- ❌ Input validation fails.
-- ❌ The execution callback returns a `WP_Error`.
-- ❌ Output validation fails.
 
 ## Usage Examples
 

--- a/docs/6.hooks.md
+++ b/docs/6.hooks.md
@@ -1,0 +1,94 @@
+# 6. Hooks
+
+The Abilities API provides WordPress action hooks that allow developers to monitor and respond to ability execution events. These hooks enable logging, debugging, analytics, and custom integrations.
+
+## Available Actions
+
+### `before_execute_ability`
+
+Fires immediately before an ability gets executed, after permission checks have passed but before the execution callback is called.
+
+```php
+/**
+ * Fires before an ability gets executed.
+ *
+ * @since n.e.x.t
+ *
+ * @param string $ability_name The name of the ability.
+ * @param mixed  $input        The input data for the ability.
+ */
+do_action( 'before_execute_ability', $ability_name, $input );
+```
+
+**Parameters:**
+
+- `$ability_name` (`string`): The namespaced name of the ability being executed (e.g., `my-plugin/get-posts`).
+- `$input` (`mixed`): The input data passed to the ability.
+
+### `after_execute_ability`
+
+Fires immediately after an ability has finished executing successfully, after output validation has passed.
+
+```php
+/**
+ * Fires immediately after an ability finished executing.
+ *
+ * @since n.e.x.t
+ *
+ * @param string $ability_name The name of the ability.
+ * @param mixed  $input        The input data for the ability.
+ * @param mixed  $result       The result of the ability execution.
+ */
+do_action( 'after_execute_ability', $ability_name, $input, $result );
+```
+
+**Parameters:**
+
+- `$ability_name` (`string`): The namespaced name of the ability that was executed.
+- `$input` (`mixed`): The input data that was passed to the ability.
+- `$result` (`mixed`): The validated result returned by the ability's execution callback.
+
+## When Actions Fire
+
+**`before_execute_ability` fires when:**
+
+- ✅ Permission checks pass.
+- ✅ Input validation succeeds (if input schema is defined).
+- ✅ Just before the execution callback is called.
+
+**`before_execute_ability` does NOT fire when:**
+
+- ❌ Permission checks fail.
+- ❌ Input validation fails.
+
+**`after_execute_ability` fires when:**
+
+- ✅ The execution callback returns successfully (not a `WP_Error`).
+- ✅ Output validation passes (if output schema is defined).
+- ✅ The ability execution completes successfully.
+
+**`after_execute_ability` does NOT fire when:**
+
+- ❌ Permission checks fail.
+- ❌ Input validation fails.
+- ❌ The execution callback returns a `WP_Error`.
+- ❌ Output validation fails.
+
+## Usage Examples
+
+**Basic Logging**
+
+```php
+// Log all ability executions.
+add_action( 'before_execute_ability', function( $ability_name, $input ) {
+    error_log( 'Executing ability: ' . $ability_name );
+    if ( $input !== null ) {
+        error_log( 'Input: ' . wp_json_encode( $input ) );
+    }
+}, 10, 2 );
+
+add_action( 'after_execute_ability', function( $ability_name, $input, $result ) {
+    error_log( 'Completed ability: ' . $ability_name );
+    error_log( 'Result: ' . wp_json_encode( $result ) );
+}, 10, 3 );
+```

--- a/includes/abilities-api.php
+++ b/includes/abilities-api.php
@@ -7,8 +7,6 @@
  * @package WordPress
  * @subpackage Abilities_API
  * @since 0.1.0
- *
- * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals
  */
 
 declare( strict_types = 1 );

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -416,14 +416,38 @@ class WP_Ability {
 			);
 		}
 
+		/**
+		 * Fires before an ability gets executed.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param string              $ability_name The name of the ability.
+		 * @param array<string,mixed> $input        The input data for the ability.
+		 */
+		do_action( 'before_execute_ability', $this->name, $input );
+
 		$result = $this->do_execute( $input );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
 
 		$is_valid = $this->validate_output( $result );
+		if ( is_wp_error( $is_valid ) ) {
+			return $is_valid;
+		}
 
-		return is_wp_error( $is_valid ) ? $is_valid : $result;
+		/**
+		 * Fires immediately after an ability finished executing.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param string              $ability_name The name of the ability.
+		 * @param array<string,mixed> $input        The input data for the ability.
+		 * @param mixed               $result       The result of the ability execution.
+		 */
+		do_action( 'executed_ability', $this->name, $input, $result );
+
+		return $result;
 	}
 
 	/**

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -421,8 +421,8 @@ class WP_Ability {
 		 *
 		 * @since n.e.x.t
 		 *
-		 * @param string              $ability_name The name of the ability.
-		 * @param array<string,mixed> $input        The input data for the ability.
+		 * @param string $ability_name The name of the ability.
+		 * @param mixed  $input        The input data for the ability.
 		 */
 		do_action( 'before_execute_ability', $this->name, $input );
 
@@ -441,9 +441,9 @@ class WP_Ability {
 		 *
 		 * @since n.e.x.t
 		 *
-		 * @param string              $ability_name The name of the ability.
-		 * @param array<string,mixed> $input        The input data for the ability.
-		 * @param mixed               $result       The result of the ability execution.
+		 * @param string $ability_name The name of the ability.
+		 * @param mixed  $input        The input data for the ability.
+		 * @param mixed  $result       The result of the ability execution.
 		 */
 		do_action( 'after_execute_ability', $this->name, $input, $result );
 

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -445,7 +445,7 @@ class WP_Ability {
 		 * @param array<string,mixed> $input        The input data for the ability.
 		 * @param mixed               $result       The result of the ability execution.
 		 */
-		do_action( 'executed_ability', $this->name, $input, $result );
+		do_action( 'after_execute_ability', $this->name, $input, $result );
 
 		return $result;
 	}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -193,11 +193,10 @@
 
 	<!-- Plugin-specific rule configs  -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<exclude-pattern>includes/abilities-api.php</exclude-pattern>
+		<exclude-pattern>includes/abilities-api/*</exclude-pattern>
 		<properties>
 			<property name="prefixes" type="array">
-				<element value="abilities_api_" /><!-- Hook prefix -->
-				<element value="WP_Ability" />
-				<element value="WP_Abilities" />
 				<element value="WP_REST_Abilities" />
 				<element value="WP_ABILITIES_API" /><!-- Constant -->
 			</property>

--- a/tests/unit/abilities-api/wpAbility.php
+++ b/tests/unit/abilities-api/wpAbility.php
@@ -180,4 +180,275 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 
 		$this->assertSame( 42, $ability->execute() );
 	}
+
+	/**
+	 * Tests that before_execute_ability action is fired with correct parameters.
+	 */
+	public function test_before_execute_ability_action() {
+		$action_ability_name = null;
+		$action_input = null;
+
+		$args = array_merge(
+			self::$test_ability_properties,
+			array(
+				'input_schema'     => array(
+					'type'        => 'integer',
+					'description' => 'Test input parameter.',
+					'required'    => true,
+				),
+				'execute_callback' => static function ( int $input ): int {
+					return $input * 2;
+				},
+			)
+		);
+
+		$callback = static function ( $ability_name, $input ) use ( &$action_ability_name, &$action_input ) {
+			$action_ability_name = $ability_name;
+			$action_input = $input;
+		};
+
+		add_action( 'before_execute_ability', $callback, 10, 2 );
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+		$result = $ability->execute( 5 );
+
+		remove_action( 'before_execute_ability', $callback );
+
+		$this->assertSame( self::$test_ability_name, $action_ability_name, 'Action should receive correct ability name' );
+		$this->assertSame( 5, $action_input, 'Action should receive correct input' );
+		$this->assertSame( 10, $result, 'Ability should execute correctly' );
+	}
+
+	/**
+	 * Tests that before_execute_ability action is fired with null input when no input schema is defined.
+	 */
+	public function test_before_execute_ability_action_no_input() {
+		$action_ability_name = null;
+		$action_input = null;
+
+		$args = array_merge(
+			self::$test_ability_properties,
+			array(
+				'execute_callback' => static function (): int {
+					return 42;
+				},
+			)
+		);
+
+		$callback = static function ( $ability_name, $input ) use ( &$action_ability_name, &$action_input ) {
+			$action_ability_name = $ability_name;
+			$action_input = $input;
+		};
+
+		add_action( 'before_execute_ability', $callback, 10, 2 );
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+		$result = $ability->execute();
+
+		remove_action( 'before_execute_ability', $callback );
+
+		$this->assertSame( self::$test_ability_name, $action_ability_name, 'Action should receive correct ability name' );
+		$this->assertNull( $action_input, 'Action should receive null input when no input provided' );
+		$this->assertSame( 42, $result, 'Ability should execute correctly' );
+	}
+
+	/**
+	 * Tests that after_execute_ability action is fired with correct parameters.
+	 */
+	public function test_after_execute_ability_action() {
+		$action_ability_name = null;
+		$action_input = null;
+		$action_result = null;
+
+		$args = array_merge(
+			self::$test_ability_properties,
+			array(
+				'input_schema'     => array(
+					'type'        => 'integer',
+					'description' => 'Test input parameter.',
+					'required'    => true,
+				),
+				'execute_callback' => static function ( int $input ): int {
+					return $input * 3;
+				},
+			)
+		);
+
+		$callback = static function ( $ability_name, $input, $result ) use ( &$action_ability_name, &$action_input, &$action_result ) {
+			$action_ability_name = $ability_name;
+			$action_input = $input;
+			$action_result = $result;
+		};
+
+		add_action( 'after_execute_ability', $callback, 10, 3 );
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+		$result = $ability->execute( 7 );
+
+		remove_action( 'after_execute_ability', $callback );
+
+		$this->assertSame( self::$test_ability_name, $action_ability_name, 'Action should receive correct ability name' );
+		$this->assertSame( 7, $action_input, 'Action should receive correct input' );
+		$this->assertSame( 21, $action_result, 'Action should receive correct result' );
+		$this->assertSame( 21, $result, 'Ability should execute correctly' );
+	}
+
+	/**
+	 * Tests that after_execute_ability action is fired with null input when no input schema is defined.
+	 */
+	public function test_after_execute_ability_action_no_input() {
+		$action_ability_name = null;
+		$action_input = null;
+		$action_result = null;
+
+		$args = array_merge(
+			self::$test_ability_properties,
+			array(
+				'output_schema'    => array(),
+				'execute_callback' => static function (): string {
+					return 'test-result';
+				},
+			)
+		);
+
+		$callback = static function ( $ability_name, $input, $result ) use ( &$action_ability_name, &$action_input, &$action_result ) {
+			$action_ability_name = $ability_name;
+			$action_input = $input;
+			$action_result = $result;
+		};
+
+		add_action( 'after_execute_ability', $callback, 10, 3 );
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+		$result = $ability->execute();
+
+		remove_action( 'after_execute_ability', $callback );
+
+		$this->assertSame( self::$test_ability_name, $action_ability_name, 'Action should receive correct ability name' );
+		$this->assertNull( $action_input, 'Action should receive null input when no input provided' );
+		$this->assertSame( 'test-result', $action_result, 'Action should receive correct result' );
+		$this->assertSame( 'test-result', $result, 'Ability should execute correctly' );
+	}
+
+	/**
+	 * Tests that neither action is fired when execution fails due to permission issues.
+	 */
+	public function test_actions_not_fired_on_permission_failure() {
+		$before_action_fired = false;
+		$after_action_fired = false;
+
+		$args = array_merge(
+			self::$test_ability_properties,
+			array(
+				'permission_callback' => static function (): bool {
+					return false;
+				},
+				'execute_callback'    => static function (): int {
+					return 42;
+				},
+			)
+		);
+
+		$before_callback = static function () use ( &$before_action_fired ) {
+			$before_action_fired = true;
+		};
+
+		$after_callback = static function () use ( &$after_action_fired ) {
+			$after_action_fired = true;
+		};
+
+		add_action( 'before_execute_ability', $before_callback );
+		add_action( 'after_execute_ability', $after_callback );
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+		$result = $ability->execute();
+
+		remove_action( 'before_execute_ability', $before_callback );
+		remove_action( 'after_execute_ability', $after_callback );
+
+		$this->assertFalse( $before_action_fired, 'before_execute_ability action should not be fired on permission failure' );
+		$this->assertFalse( $after_action_fired, 'after_execute_ability action should not be fired on permission failure' );
+		$this->assertInstanceOf( WP_Error::class, $result, 'Should return WP_Error on permission failure' );
+	}
+
+	/**
+	 * Tests that after_execute_ability action is not fired when execution callback returns WP_Error.
+	 */
+	public function test_after_action_not_fired_on_execution_error() {
+		$before_action_fired = false;
+		$after_action_fired = false;
+
+		$args = array_merge(
+			self::$test_ability_properties,
+			array(
+				'execute_callback' => static function () {
+					return new WP_Error( 'test_error', 'Test execution error' );
+				},
+			)
+		);
+
+		$before_callback = static function () use ( &$before_action_fired ) {
+			$before_action_fired = true;
+		};
+
+		$after_callback = static function () use ( &$after_action_fired ) {
+			$after_action_fired = true;
+		};
+
+		add_action( 'before_execute_ability', $before_callback );
+		add_action( 'after_execute_ability', $after_callback );
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+		$result = $ability->execute();
+
+		remove_action( 'before_execute_ability', $before_callback );
+		remove_action( 'after_execute_ability', $after_callback );
+
+		$this->assertTrue( $before_action_fired, 'before_execute_ability action should be fired even if execution fails' );
+		$this->assertFalse( $after_action_fired, 'after_execute_ability action should not be fired when execution returns WP_Error' );
+		$this->assertInstanceOf( WP_Error::class, $result, 'Should return WP_Error from execution callback' );
+	}
+
+	/**
+	 * Tests that after_execute_ability action is not fired when output validation fails.
+	 */
+	public function test_after_action_not_fired_on_output_validation_error() {
+		$before_action_fired = false;
+		$after_action_fired = false;
+
+		$args = array_merge(
+			self::$test_ability_properties,
+			array(
+				'output_schema'    => array(
+					'type'        => 'string',
+					'description' => 'Expected string output.',
+					'required'    => true,
+				),
+				'execute_callback' => static function (): int {
+					return 42;
+				},
+			)
+		);
+
+		$before_callback = static function () use ( &$before_action_fired ) {
+			$before_action_fired = true;
+		};
+
+		$after_callback = static function () use ( &$after_action_fired ) {
+			$after_action_fired = true;
+		};
+
+		add_action( 'before_execute_ability', $before_callback );
+		add_action( 'after_execute_ability', $after_callback );
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+		$result = $ability->execute();
+
+		remove_action( 'before_execute_ability', $before_callback );
+		remove_action( 'after_execute_ability', $after_callback );
+
+		$this->assertTrue( $before_action_fired, 'before_execute_ability action should be fired even if output validation fails' );
+		$this->assertFalse( $after_action_fired, 'after_execute_ability action should not be fired when output validation fails' );
+		$this->assertInstanceOf( WP_Error::class, $result, 'Should return WP_Error for output validation failure' );
+	}
 }

--- a/tests/unit/abilities-api/wpAbility.php
+++ b/tests/unit/abilities-api/wpAbility.php
@@ -186,7 +186,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	 */
 	public function test_before_execute_ability_action() {
 		$action_ability_name = null;
-		$action_input = null;
+		$action_input        = null;
 
 		$args = array_merge(
 			self::$test_ability_properties,
@@ -204,13 +204,13 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 
 		$callback = static function ( $ability_name, $input ) use ( &$action_ability_name, &$action_input ) {
 			$action_ability_name = $ability_name;
-			$action_input = $input;
+			$action_input        = $input;
 		};
 
 		add_action( 'before_execute_ability', $callback, 10, 2 );
 
 		$ability = new WP_Ability( self::$test_ability_name, $args );
-		$result = $ability->execute( 5 );
+		$result  = $ability->execute( 5 );
 
 		remove_action( 'before_execute_ability', $callback );
 
@@ -224,7 +224,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	 */
 	public function test_before_execute_ability_action_no_input() {
 		$action_ability_name = null;
-		$action_input = null;
+		$action_input        = null;
 
 		$args = array_merge(
 			self::$test_ability_properties,
@@ -237,13 +237,13 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 
 		$callback = static function ( $ability_name, $input ) use ( &$action_ability_name, &$action_input ) {
 			$action_ability_name = $ability_name;
-			$action_input = $input;
+			$action_input        = $input;
 		};
 
 		add_action( 'before_execute_ability', $callback, 10, 2 );
 
 		$ability = new WP_Ability( self::$test_ability_name, $args );
-		$result = $ability->execute();
+		$result  = $ability->execute();
 
 		remove_action( 'before_execute_ability', $callback );
 
@@ -257,8 +257,8 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	 */
 	public function test_after_execute_ability_action() {
 		$action_ability_name = null;
-		$action_input = null;
-		$action_result = null;
+		$action_input        = null;
+		$action_result       = null;
 
 		$args = array_merge(
 			self::$test_ability_properties,
@@ -276,14 +276,14 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 
 		$callback = static function ( $ability_name, $input, $result ) use ( &$action_ability_name, &$action_input, &$action_result ) {
 			$action_ability_name = $ability_name;
-			$action_input = $input;
-			$action_result = $result;
+			$action_input        = $input;
+			$action_result       = $result;
 		};
 
 		add_action( 'after_execute_ability', $callback, 10, 3 );
 
 		$ability = new WP_Ability( self::$test_ability_name, $args );
-		$result = $ability->execute( 7 );
+		$result  = $ability->execute( 7 );
 
 		remove_action( 'after_execute_ability', $callback );
 
@@ -298,8 +298,8 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	 */
 	public function test_after_execute_ability_action_no_input() {
 		$action_ability_name = null;
-		$action_input = null;
-		$action_result = null;
+		$action_input        = null;
+		$action_result       = null;
 
 		$args = array_merge(
 			self::$test_ability_properties,
@@ -313,14 +313,14 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 
 		$callback = static function ( $ability_name, $input, $result ) use ( &$action_ability_name, &$action_input, &$action_result ) {
 			$action_ability_name = $ability_name;
-			$action_input = $input;
-			$action_result = $result;
+			$action_input        = $input;
+			$action_result       = $result;
 		};
 
 		add_action( 'after_execute_ability', $callback, 10, 3 );
 
 		$ability = new WP_Ability( self::$test_ability_name, $args );
-		$result = $ability->execute();
+		$result  = $ability->execute();
 
 		remove_action( 'after_execute_ability', $callback );
 
@@ -335,7 +335,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	 */
 	public function test_actions_not_fired_on_permission_failure() {
 		$before_action_fired = false;
-		$after_action_fired = false;
+		$after_action_fired  = false;
 
 		$args = array_merge(
 			self::$test_ability_properties,
@@ -361,7 +361,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 		add_action( 'after_execute_ability', $after_callback );
 
 		$ability = new WP_Ability( self::$test_ability_name, $args );
-		$result = $ability->execute();
+		$result  = $ability->execute();
 
 		remove_action( 'before_execute_ability', $before_callback );
 		remove_action( 'after_execute_ability', $after_callback );
@@ -376,7 +376,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	 */
 	public function test_after_action_not_fired_on_execution_error() {
 		$before_action_fired = false;
-		$after_action_fired = false;
+		$after_action_fired  = false;
 
 		$args = array_merge(
 			self::$test_ability_properties,
@@ -399,7 +399,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 		add_action( 'after_execute_ability', $after_callback );
 
 		$ability = new WP_Ability( self::$test_ability_name, $args );
-		$result = $ability->execute();
+		$result  = $ability->execute();
 
 		remove_action( 'before_execute_ability', $before_callback );
 		remove_action( 'after_execute_ability', $after_callback );
@@ -414,7 +414,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	 */
 	public function test_after_action_not_fired_on_output_validation_error() {
 		$before_action_fired = false;
-		$after_action_fired = false;
+		$after_action_fired  = false;
 
 		$args = array_merge(
 			self::$test_ability_properties,
@@ -442,7 +442,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 		add_action( 'after_execute_ability', $after_callback );
 
 		$ability = new WP_Ability( self::$test_ability_name, $args );
-		$result = $ability->execute();
+		$result  = $ability->execute();
 
 		remove_action( 'before_execute_ability', $before_callback );
 		remove_action( 'after_execute_ability', $after_callback );


### PR DESCRIPTION
Illustration for the ideas to make abilities more extensible:
- https://github.com/WordPress/abilities-api/issues/39

This PR adds extensibility hooks to the ability execution flow by introducing two action hooks that fire before and after ability execution. This allows developers to hook into the ability lifecycle for monitoring, logging, or extending functionality.

- Added `before_execute_ability` action hook that fires before ability execution
- Added `after_execute_ability` action hook that fires after successful ability execution
- Refactored the return logic to properly handle validation errors and execute the post-execution hook only on success. It is up for debate what to do on error.

## Example Usage

**Basic Logging**

```php
// Log all ability executions.
add_action( 'before_execute_ability', function( $ability_name, $input ) {
    error_log( 'Executing ability: ' . $ability_name );
    if ( $input !== null ) {
        error_log( 'Input: ' . wp_json_encode( $input ) );
    }
}, 10, 2 );

add_action( 'after_execute_ability', function( $ability_name, $input, $result ) {
    error_log( 'Completed ability: ' . $ability_name );
    error_log( 'Result: ' . wp_json_encode( $result ) );
}, 10, 3 );
```

