### PR TITLE
Updated Inline Documentation Order

### DIFF
--- a/includes/abilities-api.php
+++ b/includes/abilities-api.php
@@ -18,9 +18,9 @@ declare( strict_types = 1 );
  *
  * Note: Do not use before the {@see 'abilities_api_init'} hook.
  *
- * @see WP_Abilities_Registry::register()
- *
  * @since 0.1.0
+ *
+ * @see WP_Abilities_Registry::register()
  *
  * @param string              $name       The name of the ability. The name must be a string containing a namespace
  *                                        prefix, i.e. `my-plugin/my-ability`. It can only contain lowercase
@@ -63,9 +63,9 @@ function wp_register_ability( string $name, array $properties = array() ): ?WP_A
 /**
  * Unregisters an ability using Abilities API.
  *
- * @see WP_Abilities_Registry::unregister()
- *
  * @since 0.1.0
+ *
+ * @see WP_Abilities_Registry::unregister()
  *
  * @param string $name The name of the registered ability, with its namespace.
  * @return ?\WP_Ability The unregistered ability instance on success, null on failure.
@@ -77,9 +77,9 @@ function wp_unregister_ability( string $name ): ?WP_Ability {
 /**
  * Retrieves a registered ability using Abilities API.
  *
- * @see WP_Abilities_Registry::get_registered()
- *
  * @since 0.1.0
+ *
+ * @see WP_Abilities_Registry::get_registered()
  *
  * @param string $name The name of the registered ability, with its namespace.
  * @return ?\WP_Ability The registered ability instance, or null if it is not registered.
@@ -91,9 +91,9 @@ function wp_get_ability( string $name ): ?WP_Ability {
 /**
  * Retrieves all registered abilities using Abilities API.
  *
- * @see WP_Abilities_Registry::get_all_registered()
- *
  * @since 0.1.0
+ *
+ * @see WP_Abilities_Registry::get_all_registered()
  *
  * @return \WP_Ability[] The array of registered abilities.
  */


### PR DESCRIPTION
Changed Documentation Order in `includes/abilities-api.php` (Added `@since` tag before `@see` tag according to [PHP Documentation Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/)
