### PR TITLE
Refactor the usage of `$properties` param to `$args` to align with WordPress usage

### DIFF
--- a/abilities-api.php
+++ b/abilities-api.php
@@ -12,7 +12,7 @@
  * Plugin URI:        https://github.com/WordPress/abilities-api
  * Description:       Provides a framework for registering and executing AI abilities in WordPress.
  * Requires at least: 6.8
- * Version:           0.1.0
+ * Version:           0.2.0
  * Requires PHP:      7.2
  * Author:            WordPress.org Contributors
  * Author URI:        https://github.com/WordPress/abilities-api/graphs/contributors

--- a/includes/abilities-api.php
+++ b/includes/abilities-api.php
@@ -22,12 +22,12 @@ declare( strict_types = 1 );
  *
  * @see WP_Abilities_Registry::register()
  *
- * @param string              $name       The name of the ability. The name must be a string containing a namespace
- *                                        prefix, i.e. `my-plugin/my-ability`. It can only contain lowercase
- *                                        alphanumeric characters, dashes and the forward slash.
- * @param array<string,mixed> $properties An associative array of properties for the ability. This should include
- *                                        `label`, `description`, `input_schema`, `output_schema`, `execute_callback`,
- *                                        `permission_callback`, `meta`, and `ability_class`.
+ * @param string              $name The name of the ability. The name must be a string containing a namespace
+ *                                  prefix, i.e. `my-plugin/my-ability`. It can only contain lowercase
+ *                                  alphanumeric characters, dashes and the forward slash.
+ * @param array<string,mixed> $args An associative array of arguments for the ability. This should include
+ *                                  `label`, `description`, `input_schema`, `output_schema`, `execute_callback`,
+ *                                  `permission_callback`, `meta`, and `ability_class`.
  * @return ?\WP_Ability An instance of registered ability on success, null on failure.
  *
  * @phpstan-param array{
@@ -40,9 +40,9 @@ declare( strict_types = 1 );
  *   meta?: array<string,mixed>,
  *   ability_class?: class-string<\WP_Ability>,
  *   ...<string, mixed>
- * } $properties
+ * } $args
  */
-function wp_register_ability( string $name, array $properties = array() ): ?WP_Ability {
+function wp_register_ability( string $name, array $args ): ?WP_Ability {
 	if ( ! did_action( 'abilities_api_init' ) ) {
 		_doing_it_wrong(
 			__FUNCTION__,
@@ -57,7 +57,7 @@ function wp_register_ability( string $name, array $properties = array() ): ?WP_A
 		return null;
 	}
 
-	return WP_Abilities_Registry::get_instance()->register( $name, $properties );
+	return WP_Abilities_Registry::get_instance()->register( $name, $args );
 }
 
 /**

--- a/includes/abilities-api/class-wp-abilities-registry.php
+++ b/includes/abilities-api/class-wp-abilities-registry.php
@@ -98,6 +98,7 @@ final class WP_Abilities_Registry {
 		unset( $args['ability_class'] );
 
 		try {
+			// WP_Ability::prepare_properties() will throw an exception if the properties are invalid.
 			$ability = new $ability_class( $name, $args );
 		} catch ( \InvalidArgumentException $e ) {
 			_doing_it_wrong(

--- a/includes/abilities-api/class-wp-abilities-registry.php
+++ b/includes/abilities-api/class-wp-abilities-registry.php
@@ -43,12 +43,12 @@ final class WP_Abilities_Registry {
 	 *
 	 * @see wp_register_ability()
 	 *
-	 * @param string              $name       The name of the ability. The name must be a string containing a namespace
-	 *                                        prefix, i.e. `my-plugin/my-ability`. It can only contain lowercase
-	 *                                        alphanumeric characters, dashes and the forward slash.
-	 * @param array<string,mixed> $properties An associative array of properties for the ability. This should include
-	 *                                        `label`, `description`, `input_schema`, `output_schema`,
-	 *                                        `execute_callback`, `permission_callback`, `meta`, and ability_class.
+	 * @param string              $name The name of the ability. The name must be a string containing a namespace
+	 *                                  prefix, i.e. `my-plugin/my-ability`. It can only contain lowercase
+	 *                                  alphanumeric characters, dashes and the forward slash.
+	 * @param array<string,mixed> $args An associative array of arguments for the ability. This should include
+	 *                                  `label`, `description`, `input_schema`, `output_schema`,
+	 *                                  `execute_callback`, `permission_callback`, `meta`, and ability_class.
 	 * @return ?\WP_Ability The registered ability instance on success, null on failure.
 	 *
 	 * @phpstan-param array{
@@ -61,9 +61,9 @@ final class WP_Abilities_Registry {
 	 *   meta?: array<string,mixed>,
 	 *   ability_class?: class-string<\WP_Ability>,
 	 *   ...<string, mixed>
-	 * } $properties
+	 * } $args
 	 */
-	public function register( string $name, array $properties = array() ): ?WP_Ability {
+	public function register( string $name, array $args ): ?WP_Ability {
 		if ( ! preg_match( '/^[a-z0-9-]+\/[a-z0-9-]+$/', $name ) ) {
 			_doing_it_wrong(
 				__METHOD__,
@@ -86,22 +86,19 @@ final class WP_Abilities_Registry {
 		}
 
 		// The class is only used to instantiate the ability, and is not a property of the ability itself.
-		if ( isset( $properties['ability_class'] ) && ! is_a( $properties['ability_class'], WP_Ability::class, true ) ) {
+		if ( isset( $args['ability_class'] ) && ! is_a( $args['ability_class'], WP_Ability::class, true ) ) {
 			_doing_it_wrong(
 				__METHOD__,
-				esc_html__( 'The ability properties should provide a valid `ability_class` that extends WP_Ability.' ),
+				esc_html__( 'The ability args should provide a valid `ability_class` that extends WP_Ability.' ),
 				'0.1.0'
 			);
 			return null;
 		}
-		$ability_class = $properties['ability_class'] ?? WP_Ability::class;
-		unset( $properties['ability_class'] );
+		$ability_class = $args['ability_class'] ?? WP_Ability::class;
+		unset( $args['ability_class'] );
 
 		try {
-			$ability = new $ability_class(
-				$name,
-				$properties
-			);
+			$ability = new $ability_class( $name, $args );
 		} catch ( \InvalidArgumentException $e ) {
 			_doing_it_wrong(
 				__METHOD__,

--- a/includes/abilities-api/class-wp-abilities-registry.php
+++ b/includes/abilities-api/class-wp-abilities-registry.php
@@ -98,7 +98,6 @@ final class WP_Abilities_Registry {
 		unset( $properties['ability_class'] );
 
 		try {
-			// WP_Ability::validate_properties() will throw an exception if the properties are invalid.
 			$ability = new $ability_class(
 				$name,
 				$properties

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -104,7 +104,7 @@ class WP_Ability {
 	public function __construct( string $name, array $properties ) {
 		$this->name = $name;
 
-		$this->validate_properties( $properties );
+		$properties = $this->prepare_args( $properties );
 
 		foreach ( $properties as $property_name => $property_value ) {
 			if ( ! property_exists( $this, $property_name ) ) {
@@ -194,7 +194,7 @@ class WP_Ability {
 	}
 
 	/**
-	 * Validates the properties used to instantiate the ability.
+	 * Prepares and validates the arguments used to instantiate the ability.
 	 *
 	 * Errors are thrown as exceptions instead of \WP_Errors to allow for simpler handling and overloading. They are then
 	 * caught and converted to a WP_Error when by WP_Abilities_Registry::register().
@@ -203,12 +203,12 @@ class WP_Ability {
 	 *
 	 * @see WP_Abilities_Registry::register()
 	 *
-	 * @param array<string,mixed> $properties An associative array of properties to validate.
+	 * @param array<string,mixed> $args An associative array of arguments used to instantiate the class.
 	 *
-	 * @return void
-	 * @throws \InvalidArgumentException if the properties are invalid.
+	 * @return array<string,mixed> The validated and prepared arguments.
+	 * @throws \InvalidArgumentException if a argument is invalid.
 	 *
-	 * @phpstan-assert array{
+	 * @phpstan-return array{
 	 *   label: string,
 	 *   description: string,
 	 *   input_schema?: array<string,mixed>,
@@ -217,50 +217,52 @@ class WP_Ability {
 	 *   permission_callback?: ?callable( array<string,mixed> $input ): (bool|\WP_Error),
 	 *   meta?: array<string,mixed>,
 	 *   ...<string, mixed>,
-	 * } $properties
+	 * } $args
 	 */
-	protected function validate_properties( array $properties ) {
-		if ( empty( $properties['label'] ) || ! is_string( $properties['label'] ) ) {
+	protected function prepare_args( array $args ): array {
+		if ( empty( $args['label'] ) || ! is_string( $args['label'] ) ) {
 			throw new \InvalidArgumentException(
 				esc_html__( 'The ability properties must contain a `label` string.' )
 			);
 		}
 
-		if ( empty( $properties['description'] ) || ! is_string( $properties['description'] ) ) {
+		if ( empty( $args['description'] ) || ! is_string( $args['description'] ) ) {
 			throw new \InvalidArgumentException(
 				esc_html__( 'The ability properties must contain a `description` string.' )
 			);
 		}
 
-		if ( isset( $properties['input_schema'] ) && ! is_array( $properties['input_schema'] ) ) {
+		if ( isset( $args['input_schema'] ) && ! is_array( $args['input_schema'] ) ) {
 			throw new \InvalidArgumentException(
 				esc_html__( 'The ability properties should provide a valid `input_schema` definition.' )
 			);
 		}
 
-		if ( isset( $properties['output_schema'] ) && ! is_array( $properties['output_schema'] ) ) {
+		if ( isset( $args['output_schema'] ) && ! is_array( $args['output_schema'] ) ) {
 			throw new \InvalidArgumentException(
 				esc_html__( 'The ability properties should provide a valid `output_schema` definition.' )
 			);
 		}
 
-		if ( empty( $properties['execute_callback'] ) || ! is_callable( $properties['execute_callback'] ) ) {
+		if ( empty( $args['execute_callback'] ) || ! is_callable( $args['execute_callback'] ) ) {
 			throw new \InvalidArgumentException(
 				esc_html__( 'The ability properties must contain a valid `execute_callback` function.' )
 			);
 		}
 
-		if ( isset( $properties['permission_callback'] ) && ! is_callable( $properties['permission_callback'] ) ) {
+		if ( isset( $args['permission_callback'] ) && ! is_callable( $args['permission_callback'] ) ) {
 			throw new \InvalidArgumentException(
 				esc_html__( 'The ability properties should provide a valid `permission_callback` function.' )
 			);
 		}
 
-		if ( isset( $properties['meta'] ) && ! is_array( $properties['meta'] ) ) {
+		if ( isset( $args['meta'] ) && ! is_array( $args['meta'] ) ) {
 			throw new \InvalidArgumentException(
 				esc_html__( 'The ability properties should provide a valid `meta` array.' )
 			);
 		}
+
+		return $args;
 	}
 
 	/**

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -96,15 +96,15 @@ class WP_Ability {
 	 *
 	 * @see wp_register_ability()
 	 *
-	 * @param string              $name       The name of the ability, with its namespace.
-	 * @param array<string,mixed> $properties An associative array of properties for the ability. This should
-	 *                                        include `label`, `description`, `input_schema`, `output_schema`,
-	 *                                        `execute_callback`, `permission_callback`, and `meta`.
+	 * @param string              $name The name of the ability, with its namespace.
+	 * @param array<string,mixed> $args An associative array of arguments for the ability. This should
+	 *                                  include `label`, `description`, `input_schema`, `output_schema`,
+	 *                                  `execute_callback`, `permission_callback`, and `meta`.
 	 */
-	public function __construct( string $name, array $properties ) {
+	public function __construct( string $name, array $args ) {
 		$this->name = $name;
 
-		$properties = $this->prepare_args( $properties );
+		$properties = $this->prepare_properties( $args );
 
 		foreach ( $properties as $property_name => $property_value ) {
 			if ( ! property_exists( $this, $property_name ) ) {
@@ -124,6 +124,77 @@ class WP_Ability {
 
 			$this->$property_name = $property_value;
 		}
+	}
+
+	/**
+	 * Prepares and validates the properties used to instantiate the ability.
+	 *
+	 * Errors are thrown as exceptions instead of \WP_Errors to allow for simpler handling and overloading. They are then
+	 * caught and converted to a WP_Error when by WP_Abilities_Registry::register().
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @see WP_Abilities_Registry::register()
+	 *
+	 * @param array<string,mixed> $args An associative array of arguments used to instantiate the class.
+	 * @return array<string,mixed> The validated and prepared properties.
+	 * @throws \InvalidArgumentException if an argument is invalid.
+	 *
+	 * @phpstan-return array{
+	 *   label: string,
+	 *   description: string,
+	 *   input_schema?: array<string,mixed>,
+	 *   output_schema?: array<string,mixed>,
+	 *   execute_callback: callable( array<string,mixed> $input): (mixed|\WP_Error),
+	 *   permission_callback?: ?callable( array<string,mixed> $input ): (bool|\WP_Error),
+	 *   meta?: array<string,mixed>,
+	 *   ...<string, mixed>,
+	 * } $args
+	 */
+	protected function prepare_properties( array $args ): array {
+		if ( empty( $args['label'] ) || ! is_string( $args['label'] ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'The ability properties must contain a `label` string.' )
+			);
+		}
+
+		if ( empty( $args['description'] ) || ! is_string( $args['description'] ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'The ability properties must contain a `description` string.' )
+			);
+		}
+
+		if ( isset( $args['input_schema'] ) && ! is_array( $args['input_schema'] ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'The ability properties should provide a valid `input_schema` definition.' )
+			);
+		}
+
+		if ( isset( $args['output_schema'] ) && ! is_array( $args['output_schema'] ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'The ability properties should provide a valid `output_schema` definition.' )
+			);
+		}
+
+		if ( empty( $args['execute_callback'] ) || ! is_callable( $args['execute_callback'] ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'The ability properties must contain a valid `execute_callback` function.' )
+			);
+		}
+
+		if ( isset( $args['permission_callback'] ) && ! is_callable( $args['permission_callback'] ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'The ability properties should provide a valid `permission_callback` function.' )
+			);
+		}
+
+		if ( isset( $args['meta'] ) && ! is_array( $args['meta'] ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'The ability properties should provide a valid `meta` array.' )
+			);
+		}
+
+		return $args;
 	}
 
 	/**
@@ -191,78 +262,6 @@ class WP_Ability {
 	 */
 	public function get_meta(): array {
 		return $this->meta;
-	}
-
-	/**
-	 * Prepares and validates the arguments used to instantiate the ability.
-	 *
-	 * Errors are thrown as exceptions instead of \WP_Errors to allow for simpler handling and overloading. They are then
-	 * caught and converted to a WP_Error when by WP_Abilities_Registry::register().
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @see WP_Abilities_Registry::register()
-	 *
-	 * @param array<string,mixed> $args An associative array of arguments used to instantiate the class.
-	 *
-	 * @return array<string,mixed> The validated and prepared arguments.
-	 * @throws \InvalidArgumentException if a argument is invalid.
-	 *
-	 * @phpstan-return array{
-	 *   label: string,
-	 *   description: string,
-	 *   input_schema?: array<string,mixed>,
-	 *   output_schema?: array<string,mixed>,
-	 *   execute_callback: callable( array<string,mixed> $input): (mixed|\WP_Error),
-	 *   permission_callback?: ?callable( array<string,mixed> $input ): (bool|\WP_Error),
-	 *   meta?: array<string,mixed>,
-	 *   ...<string, mixed>,
-	 * } $args
-	 */
-	protected function prepare_args( array $args ): array {
-		if ( empty( $args['label'] ) || ! is_string( $args['label'] ) ) {
-			throw new \InvalidArgumentException(
-				esc_html__( 'The ability properties must contain a `label` string.' )
-			);
-		}
-
-		if ( empty( $args['description'] ) || ! is_string( $args['description'] ) ) {
-			throw new \InvalidArgumentException(
-				esc_html__( 'The ability properties must contain a `description` string.' )
-			);
-		}
-
-		if ( isset( $args['input_schema'] ) && ! is_array( $args['input_schema'] ) ) {
-			throw new \InvalidArgumentException(
-				esc_html__( 'The ability properties should provide a valid `input_schema` definition.' )
-			);
-		}
-
-		if ( isset( $args['output_schema'] ) && ! is_array( $args['output_schema'] ) ) {
-			throw new \InvalidArgumentException(
-				esc_html__( 'The ability properties should provide a valid `output_schema` definition.' )
-			);
-		}
-
-		if ( empty( $args['execute_callback'] ) || ! is_callable( $args['execute_callback'] ) ) {
-			throw new \InvalidArgumentException(
-				esc_html__( 'The ability properties must contain a valid `execute_callback` function.' )
-			);
-		}
-
-		if ( isset( $args['permission_callback'] ) && ! is_callable( $args['permission_callback'] ) ) {
-			throw new \InvalidArgumentException(
-				esc_html__( 'The ability properties should provide a valid `permission_callback` function.' )
-			);
-		}
-
-		if ( isset( $args['meta'] ) && ! is_array( $args['meta'] ) ) {
-			throw new \InvalidArgumentException(
-				esc_html__( 'The ability properties should provide a valid `meta` array.' )
-			);
-		}
-
-		return $args;
 	}
 
 	/**

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -132,7 +132,7 @@ class WP_Ability {
 	 * Errors are thrown as exceptions instead of \WP_Errors to allow for simpler handling and overloading. They are then
 	 * caught and converted to a WP_Error when by WP_Abilities_Registry::register().
 	 *
-	 * @since n.e.x.t
+	 * @since 0.2.0
 	 *
 	 * @see WP_Abilities_Registry::register()
 	 *

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Version of the plugin.
 if ( ! defined( 'WP_ABILITIES_API_VERSION' ) ) {
-	define( 'WP_ABILITIES_API_VERSION', '0.1.0' );
+	define( 'WP_ABILITIES_API_VERSION', '0.2.0' );
 }
 
 // Load core classes if they are not already defined (for non-Composer installs or direct includes).

--- a/tests/unit/abilities-api/wpAbilitiesRegistry.php
+++ b/tests/unit/abilities-api/wpAbilitiesRegistry.php
@@ -10,7 +10,7 @@
 class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 
 	public static $test_ability_name       = 'test/add-numbers';
-	public static $test_ability_properties = array();
+	public static $test_ability_args = array();
 
 	/**
 	 * Mock abilities registry.
@@ -27,7 +27,7 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 
 		$this->registry = new WP_Abilities_Registry();
 
-		self::$test_ability_properties = array(
+		self::$test_ability_args = array(
 			'label'               => 'Add numbers',
 			'description'         => 'Calculates the result of adding two numbers.',
 			'input_schema'        => array(
@@ -80,7 +80,7 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage WP_Abilities_Registry::register
 	 */
 	public function test_register_invalid_name_without_namespace() {
-		$result = $this->registry->register( 'without-namespace', self::$test_ability_properties );
+		$result = $this->registry->register( 'without-namespace', self::$test_ability_args );
 		$this->assertNull( $result );
 	}
 
@@ -104,7 +104,7 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage WP_Abilities_Registry::register
 	 */
 	public function test_register_invalid_uppercase_characters_in_name() {
-		$result = $this->registry->register( 'Test/AddNumbers', self::$test_ability_properties );
+		$result = $this->registry->register( 'Test/AddNumbers', self::$test_ability_args );
 		$this->assertNull( $result );
 	}
 
@@ -116,10 +116,10 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage WP_Abilities_Registry::register
 	 */
 	public function test_register_invalid_missing_label() {
-		// Remove the label from the properties.
-		unset( self::$test_ability_properties['label'] );
+		// Remove the label from the args.
+		unset( self::$test_ability_args['label'] );
 
-		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_properties );
+		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_args );
 		$this->assertNull( $result );
 	}
 
@@ -131,9 +131,9 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage WP_Abilities_Registry::register
 	 */
 	public function test_register_invalid_label_type() {
-		self::$test_ability_properties['label'] = false;
+		self::$test_ability_args['label'] = false;
 
-		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_properties );
+		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_args );
 		$this->assertNull( $result );
 	}
 
@@ -145,10 +145,10 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage WP_Abilities_Registry::register
 	 */
 	public function test_register_invalid_missing_description() {
-		// Remove the description from the properties.
-		unset( self::$test_ability_properties['description'] );
+		// Remove the description from the args.
+		unset( self::$test_ability_args['description'] );
 
-		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_properties );
+		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_args );
 		$this->assertNull( $result );
 	}
 
@@ -160,9 +160,9 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage WP_Abilities_Registry::register
 	 */
 	public function test_register_invalid_description_type() {
-		self::$test_ability_properties['description'] = false;
+		self::$test_ability_args['description'] = false;
 
-		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_properties );
+		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_args );
 		$this->assertNull( $result );
 	}
 
@@ -174,10 +174,10 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage WP_Abilities_Registry::register
 	 */
 	public function test_register_invalid_missing_execute_callback() {
-		// Remove the execute_callback from the properties.
-		unset( self::$test_ability_properties['execute_callback'] );
+		// Remove the execute_callback from the args.
+		unset( self::$test_ability_args['execute_callback'] );
 
-		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_properties );
+		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_args );
 		$this->assertNull( $result );
 	}
 
@@ -189,9 +189,9 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage WP_Abilities_Registry::register
 	 */
 	public function test_register_incorrect_execute_callback_type() {
-		self::$test_ability_properties['execute_callback'] = 'not-a-callback';
+		self::$test_ability_args['execute_callback'] = 'not-a-callback';
 
-		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_properties );
+		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_args );
 		$this->assertNull( $result );
 	}
 
@@ -203,9 +203,9 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage WP_Abilities_Registry::register
 	 */
 	public function test_register_incorrect_permission_callback_type() {
-		self::$test_ability_properties['permission_callback'] = 'not-a-callback';
+		self::$test_ability_args['permission_callback'] = 'not-a-callback';
 
-		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_properties );
+		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_args );
 		$this->assertNull( $result );
 	}
 
@@ -217,9 +217,9 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage WP_Abilities_Registry::register
 	 */
 	public function test_register_incorrect_input_schema_type() {
-		self::$test_ability_properties['input_schema'] = 'not-an-array';
+		self::$test_ability_args['input_schema'] = 'not-an-array';
 
-		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_properties );
+		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_args );
 		$this->assertNull( $result );
 	}
 
@@ -231,9 +231,9 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage WP_Abilities_Registry::register
 	 */
 	public function test_register_incorrect_output_schema_type() {
-		self::$test_ability_properties['output_schema'] = 'not-an-array';
+		self::$test_ability_args['output_schema'] = 'not-an-array';
 
-		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_properties );
+		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_args );
 		$this->assertNull( $result );
 	}
 
@@ -245,9 +245,9 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage WP_Abilities_Registry::register
 	 */
 	public function test_register_invalid_meta_type() {
-		self::$test_ability_properties['meta'] = false;
+		self::$test_ability_args['meta'] = false;
 
-		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_properties );
+		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_args );
 		$this->assertNull( $result );
 	}
 
@@ -259,9 +259,9 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage WP_Abilities_Registry::register
 	 */
 	public function test_register_incorrect_already_registered_ability() {
-		$this->registry->register( self::$test_ability_name, self::$test_ability_properties );
+		$this->registry->register( self::$test_ability_name, self::$test_ability_args );
 
-		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_properties );
+		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_args );
 
 		$this->assertNull( $result );
 	}
@@ -272,10 +272,10 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * @covers WP_Abilities_Registry::register
 	 */
 	public function test_register_new_ability() {
-		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_properties );
+		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_args );
 
 		$this->assertEquals(
-			new WP_Ability( self::$test_ability_name, self::$test_ability_properties ),
+			new WP_Ability( self::$test_ability_name, self::$test_ability_args ),
 			$result
 		);
 	}
@@ -297,9 +297,9 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * @covers WP_Abilities_Registry::is_registered
 	 */
 	public function test_is_registered_for_known_ability() {
-		$this->registry->register( 'test/one', self::$test_ability_properties );
-		$this->registry->register( 'test/two', self::$test_ability_properties );
-		$this->registry->register( 'test/three', self::$test_ability_properties );
+		$this->registry->register( 'test/one', self::$test_ability_args );
+		$this->registry->register( 'test/two', self::$test_ability_args );
+		$this->registry->register( 'test/three', self::$test_ability_args );
 
 		$result = $this->registry->is_registered( 'test/one' );
 		$this->assertTrue( $result );
@@ -324,9 +324,9 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * @covers WP_Abilities_Registry::get_registered
 	 */
 	public function test_get_registered_for_known_ability() {
-		$this->registry->register( 'test/one', self::$test_ability_properties );
-		$this->registry->register( 'test/two', self::$test_ability_properties );
-		$this->registry->register( 'test/three', self::$test_ability_properties );
+		$this->registry->register( 'test/one', self::$test_ability_args );
+		$this->registry->register( 'test/two', self::$test_ability_args );
+		$this->registry->register( 'test/three', self::$test_ability_args );
 
 		$result = $this->registry->get_registered( 'test/two' );
 		$this->assertEquals( 'test/two', $result->get_name() );
@@ -351,9 +351,9 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * @covers WP_Abilities_Registry::unregister
 	 */
 	public function test_unregister_for_known_ability() {
-		$this->registry->register( 'test/one', self::$test_ability_properties );
-		$this->registry->register( 'test/two', self::$test_ability_properties );
-		$this->registry->register( 'test/three', self::$test_ability_properties );
+		$this->registry->register( 'test/one', self::$test_ability_args );
+		$this->registry->register( 'test/two', self::$test_ability_args );
+		$this->registry->register( 'test/three', self::$test_ability_args );
 
 		$result = $this->registry->unregister( 'test/three' );
 		$this->assertEquals( 'test/three', $result->get_name() );
@@ -369,13 +369,13 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 */
 	public function test_get_all_registered() {
 		$ability_one_name = 'test/one';
-		$this->registry->register( $ability_one_name, self::$test_ability_properties );
+		$this->registry->register( $ability_one_name, self::$test_ability_args );
 
 		$ability_two_name = 'test/two';
-		$this->registry->register( $ability_two_name, self::$test_ability_properties );
+		$this->registry->register( $ability_two_name, self::$test_ability_args );
 
 		$ability_three_name = 'test/three';
-		$this->registry->register( $ability_three_name, self::$test_ability_properties );
+		$this->registry->register( $ability_three_name, self::$test_ability_args );
 
 		$result = $this->registry->get_all_registered();
 		$this->assertCount( 3, $result );
@@ -388,7 +388,7 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * Direct instantiation of WP_Ability with invalid properties should throw an exception.
 	 *
 	 * @covers WP_Ability::__construct
-	 * @covers WP_Ability::validate_properties
+	 * @covers WP_Ability::prepare_properties
 	 */
 	public function test_wp_ability_invalid_properties_throws_exception() {
 		$this->expectException( \InvalidArgumentException::class );

--- a/tests/unit/abilities-api/wpAbilitiesRegistry.php
+++ b/tests/unit/abilities-api/wpAbilitiesRegistry.php
@@ -9,7 +9,7 @@
  */
 class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 
-	public static $test_ability_name       = 'test/add-numbers';
+	public static $test_ability_name = 'test/add-numbers';
 	public static $test_ability_args = array();
 
 	/**

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -22,7 +22,7 @@ class Mock_Custom_Ability extends WP_Ability {
 class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 
 	public static $test_ability_name       = 'test/add-numbers';
-	public static $test_ability_properties = array();
+	public static $test_ability_args = array();
 
 	/**
 	 * Set up before each test.
@@ -30,7 +30,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	public function set_up(): void {
 		parent::set_up();
 
-		self::$test_ability_properties = array(
+		self::$test_ability_args = array(
 			'label'               => 'Add numbers',
 			'description'         => 'Calculates the result of adding two numbers.',
 			'input_schema'        => array(
@@ -108,7 +108,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 		// Reset the action count to simulate it not being fired
 		unset( $wp_actions['abilities_api_init'] );
 
-		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_properties );
+		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
 
 		// Restore the original action count
 		if ( $original_count > 0 ) {
@@ -124,15 +124,15 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	public function test_register_valid_ability(): void {
 		do_action( 'abilities_api_init' );
 
-		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_properties );
+		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
 
 		$this->assertInstanceOf( WP_Ability::class, $result );
 		$this->assertSame( self::$test_ability_name, $result->get_name() );
-		$this->assertSame( self::$test_ability_properties['label'], $result->get_label() );
-		$this->assertSame( self::$test_ability_properties['description'], $result->get_description() );
-		$this->assertSame( self::$test_ability_properties['input_schema'], $result->get_input_schema() );
-		$this->assertSame( self::$test_ability_properties['output_schema'], $result->get_output_schema() );
-		$this->assertSame( self::$test_ability_properties['meta'], $result->get_meta() );
+		$this->assertSame( self::$test_ability_args['label'], $result->get_label() );
+		$this->assertSame( self::$test_ability_args['description'], $result->get_description() );
+		$this->assertSame( self::$test_ability_args['input_schema'], $result->get_input_schema() );
+		$this->assertSame( self::$test_ability_args['output_schema'], $result->get_output_schema() );
+		$this->assertSame( self::$test_ability_args['meta'], $result->get_meta() );
 		$this->assertTrue(
 			$result->has_permission(
 				array(
@@ -158,10 +158,10 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	public function test_register_ability_no_permissions(): void {
 		do_action( 'abilities_api_init' );
 
-		self::$test_ability_properties['permission_callback'] = static function (): bool {
+		self::$test_ability_args['permission_callback'] = static function (): bool {
 			return false;
 		};
-		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_properties );
+		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
 
 		$this->assertFalse(
 			$result->has_permission(
@@ -194,7 +194,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 		$result = wp_register_ability(
 			self::$test_ability_name,
 			array_merge(
-				self::$test_ability_properties,
+				self::$test_ability_args,
 				array(
 					'ability_class' => Mock_Custom_Ability::class,
 				)
@@ -217,7 +217,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 		wp_register_ability(
 			self::$test_ability_name,
 			array_merge(
-				self::$test_ability_properties,
+				self::$test_ability_args,
 				array(
 					'ability_class' => 'Non_Existent_Class',
 				)
@@ -232,7 +232,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	public function test_execute_ability_no_input_schema_match(): void {
 		do_action( 'abilities_api_init' );
 
-		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_properties );
+		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
 
 		$actual = $result->execute(
 			array(
@@ -259,10 +259,10 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	public function test_execute_ability_no_output_schema_match(): void {
 		do_action( 'abilities_api_init' );
 
-		self::$test_ability_properties['execute_callback'] = static function (): bool {
+		self::$test_ability_args['execute_callback'] = static function (): bool {
 			return true;
 		};
-		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_properties );
+		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
 
 		$actual = $result->execute(
 			array(
@@ -287,7 +287,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	public function test_permission_callback_no_input_schema_match(): void {
 		do_action( 'abilities_api_init' );
 
-		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_properties );
+		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
 
 		$actual = $result->has_permission(
 			array(
@@ -315,13 +315,13 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 		do_action( 'abilities_api_init' );
 
 		$received_input                                       = null;
-		self::$test_ability_properties['permission_callback'] = static function ( array $input ) use ( &$received_input ): bool {
+		self::$test_ability_args['permission_callback'] = static function ( array $input ) use ( &$received_input ): bool {
 			$received_input = $input;
 			// Allow only if 'a' is greater than 'b'
 			return $input['a'] > $input['b'];
 		};
 
-		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_properties );
+		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
 
 		// Test with a > b (should be allowed)
 		$this->assertTrue(
@@ -364,12 +364,12 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	public function test_unregister_existing_ability() {
 		do_action( 'abilities_api_init' );
 
-		wp_register_ability( self::$test_ability_name, self::$test_ability_properties );
+		wp_register_ability( self::$test_ability_name, self::$test_ability_args );
 
 		$result = wp_unregister_ability( self::$test_ability_name );
 
 		$this->assertEquals(
-			new WP_Ability( self::$test_ability_name, self::$test_ability_properties ),
+			new WP_Ability( self::$test_ability_name, self::$test_ability_args ),
 			$result
 		);
 	}
@@ -379,9 +379,9 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	 */
 	public function test_get_existing_ability() {
 		$name       = self::$test_ability_name;
-		$properties = self::$test_ability_properties;
-		$callback   = static function ( $instance ) use ( $name, $properties ) {
-			wp_register_ability( $name, $properties );
+		$args = self::$test_ability_args;
+		$callback   = static function ( $instance ) use ( $name, $args ) {
+			wp_register_ability( $name, $args );
 		};
 
 		add_action( 'abilities_api_init', $callback );
@@ -397,7 +397,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 		remove_action( 'abilities_api_init', $callback );
 
 		$this->assertEquals(
-			new WP_Ability( $name, $properties ),
+			new WP_Ability( $name, $args ),
 			$result,
 			'Ability does not share expected properties.'
 		);
@@ -410,21 +410,21 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 		do_action( 'abilities_api_init' );
 
 		$ability_one_name       = 'test/ability-one';
-		$ability_one_properties = self::$test_ability_properties;
-		wp_register_ability( $ability_one_name, $ability_one_properties );
+		$ability_one_args = self::$test_ability_args;
+		wp_register_ability( $ability_one_name, $ability_one_args );
 
 		$ability_two_name       = 'test/ability-two';
-		$ability_two_properties = self::$test_ability_properties;
-		wp_register_ability( $ability_two_name, $ability_two_properties );
+		$ability_two_args = self::$test_ability_args;
+		wp_register_ability( $ability_two_name, $ability_two_args );
 
 		$ability_three_name       = 'test/ability-three';
-		$ability_three_properties = self::$test_ability_properties;
-		wp_register_ability( $ability_three_name, $ability_three_properties );
+		$ability_three_args = self::$test_ability_args;
+		wp_register_ability( $ability_three_name, $ability_three_args );
 
 		$expected = array(
-			$ability_one_name   => new WP_Ability( $ability_one_name, $ability_one_properties ),
-			$ability_two_name   => new WP_Ability( $ability_two_name, $ability_two_properties ),
-			$ability_three_name => new WP_Ability( $ability_three_name, $ability_three_properties ),
+			$ability_one_name   => new WP_Ability( $ability_one_name, $ability_one_args ),
+			$ability_two_name   => new WP_Ability( $ability_two_name, $ability_two_args ),
+			$ability_three_name => new WP_Ability( $ability_three_name, $ability_three_args ),
 		);
 
 		$result = wp_get_abilities();

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -391,7 +391,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 		$registry_reflection = new ReflectionClass( WP_Abilities_Registry::class );
 		$instance_prop       = $registry_reflection->getProperty( 'instance' );
 		$instance_prop->setAccessible( true );
-		$instance_prop->setValue( null );
+		$instance_prop->setValue( null, null );
 
 		$result = wp_get_ability( $name );
 

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -262,6 +262,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 		self::$test_ability_args['execute_callback'] = static function (): bool {
 			return true;
 		};
+
 		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
 
 		$actual = $result->execute(

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -21,7 +21,7 @@ class Mock_Custom_Ability extends WP_Ability {
  */
 class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 
-	public static $test_ability_name       = 'test/add-numbers';
+	public static $test_ability_name = 'test/add-numbers';
 	public static $test_ability_args = array();
 
 	/**
@@ -314,7 +314,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	public function test_permission_callback_receives_input(): void {
 		do_action( 'abilities_api_init' );
 
-		$received_input                                       = null;
+		$received_input                                 = null;
 		self::$test_ability_args['permission_callback'] = static function ( array $input ) use ( &$received_input ): bool {
 			$received_input = $input;
 			// Allow only if 'a' is greater than 'b'
@@ -378,9 +378,9 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	 * Tests retrieving existing ability.
 	 */
 	public function test_get_existing_ability() {
-		$name       = self::$test_ability_name;
-		$args = self::$test_ability_args;
-		$callback   = static function ( $instance ) use ( $name, $args ) {
+		$name     = self::$test_ability_name;
+		$args     = self::$test_ability_args;
+		$callback = static function ( $instance ) use ( $name, $args ) {
 			wp_register_ability( $name, $args );
 		};
 
@@ -409,15 +409,15 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	public function test_get_all_registered_abilities() {
 		do_action( 'abilities_api_init' );
 
-		$ability_one_name       = 'test/ability-one';
+		$ability_one_name = 'test/ability-one';
 		$ability_one_args = self::$test_ability_args;
 		wp_register_ability( $ability_one_name, $ability_one_args );
 
-		$ability_two_name       = 'test/ability-two';
+		$ability_two_name = 'test/ability-two';
 		$ability_two_args = self::$test_ability_args;
 		wp_register_ability( $ability_two_name, $ability_two_args );
 
-		$ability_three_name       = 'test/ability-three';
+		$ability_three_name = 'test/ability-three';
 		$ability_three_args = self::$test_ability_args;
 		wp_register_ability( $ability_three_name, $ability_three_args );
 


### PR DESCRIPTION
Follow up for:
- https://github.com/WordPress/abilities-api/pull/54

More details in this https://github.com/WordPress/abilities-api/pull/54#discussion_r2316593195. The most relevant part from @justlevine:

> My takeaway from this conversation is that we're good not caring about that last point (between overloading and the filter if someone really, realy thinks shimming a DTO or VO into this api is a good idea, they have ways), so if y'all don't think it's outweighed by the first two (I don't), I'll use `prepare_*`( `array<string,mixed>` ): `array<valid-shape>` and just `throw`.

This PR refactors the usage of `$properties` to `$args` to reflect the conversation. As part of the refactoring, the definition for ability registration was also updated to remove the optionality of `$args` because to work correctly, there needs to be at least `ability_class` passed, or more frequently, three fields: `label`, `description`, and `execute_callback`.

Entire codebase was slightly refactored to follow the convention agreed upon.