### PR TITLE
Change package type from library to wordpress-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "wordpress/abilities-api",
 	"description": "AI Abilities for WordPress.",
 	"license": "GPL-2.0-or-later",
-	"type": "library",
+	"type": "wordpress-plugin",
 	"keywords": [
 		"ai",
 		"api",


### PR DESCRIPTION
To use Composer for installing into the plugins folder, the type should be 'wordpress-plugin'.
To use Composer as commonly set up for WordPress, and in the mcp-adapter README, the type should be updated.

Docs:

#### With Composer

Until the plugin is available on Packagist, you will need to add the repository to your `composer.json` file.


```jsonc
{
  "repositories": [
    {
      "type": "vcs",
      "url": "https://github.com/WordPress/abilities-api.git"
    },
    // ... other repositories.
  ],
  "extra": {
    "installer-paths": {
      // This should match your WordPress+Composer setup.
      "wp-content/plugins/{$name}/": [
          "type:wordpress-plugin"
      ]
      // .. other paths.
    }
  }
  // ... rest of your composer.json.
}
```

Then, require the package in your project:

```bash
composer require wordpress/abilities-api
```
