### PR TITLE
Docs: REST API Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [Getting Started](docs/2.getting-started.md)
 - [Registering Abilities](docs/3.registering-abilities.md)
 - [Using Abilities](docs/4.using-abilities.md)
+- [REST API Reference](docs/5.rest-api.md)
 - [Contributing Guidelines](CONTRIBUTING.md)
 
 ## Inspiration
@@ -33,7 +34,7 @@
 ## Current Status
 
 | Milestone                           | State       |
-| ----------------------------------- |-------------|
+| ----------------------------------- | ----------- |
 | Placeholder repository              | **created** |
 | Spec draft                          | in progress |
 | Prototype plugin & Composer package | in progress |

--- a/docs/5.rest-api.md
+++ b/docs/5.rest-api.md
@@ -14,17 +14,19 @@ Abilities are represented in JSON with the following structure:
 {
   "name": "my-plugin/get-site-info",
   "label": "Get Site Information",
-  "description": "Retrieves basic information about the WordPress site",
-  "input_schema": {
-    "type": "object",
-    "properties": {},
-    "additionalProperties": false
-  },
+  "description": "Retrieves basic information about the WordPress site.",
   "output_schema": {
     "type": "object",
     "properties": {
-      "name": {"type": "string"},
-      "url": {"type": "string", "format": "uri"}
+      "name": {
+        "type": "string",
+        "description": "Site name"
+      },
+      "url": {
+        "type": "string",
+        "format": "uri",
+        "description": "Site URL"
+      }
     }
   },
   "meta": {}
@@ -39,8 +41,8 @@ Abilities are represented in JSON with the following structure:
 
 ### Arguments
 
-- `page` *(integer)*: Current page of the collection. Default: `1`
-- `per_page` *(integer)*: Maximum number of items to return per page. Default: `50`, Maximum: `100`
+- `page` _(integer)_: Current page of the collection. Default: `1`.
+- `per_page` _(integer)_: Maximum number of items to return per page. Default: `50`, Maximum: `100`.
 
 ### Example Request
 
@@ -55,18 +57,18 @@ curl https://example.com/wp-json/wp/v2/abilities
   {
     "name": "my-plugin/get-site-info",
     "label": "Get Site Information",
-    "description": "Retrieves basic information about the WordPress site",
-    "input_schema": {
-      "type": "object",
-      "properties": {},
-      "additionalProperties": false
-    },
+    "description": "Retrieves basic information about the WordPress site.",
     "output_schema": {
       "type": "object",
       "properties": {
         "name": {
           "type": "string",
           "description": "Site name"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Site URL"
         }
       }
     },
@@ -83,8 +85,8 @@ curl https://example.com/wp-json/wp/v2/abilities
 
 ### Arguments
 
-- `namespace` *(string)*: The namespace part of the ability name
-- `ability` *(string)*: The ability name part
+- `namespace` _(string)_: The namespace part of the ability name.
+- `ability` _(string)_: The ability name part.
 
 ### Example Request
 
@@ -98,12 +100,7 @@ curl https://example.com/wp-json/wp/v2/abilities/my-plugin/get-site-info
 {
   "name": "my-plugin/get-site-info",
   "label": "Get Site Information",
-  "description": "Retrieves basic information about the WordPress site",
-  "input_schema": {
-    "type": "object",
-    "properties": {},
-    "additionalProperties": false
-  },
+  "description": "Retrieves basic information about the WordPress site.",
   "output_schema": {
     "type": "object",
     "properties": {
@@ -118,9 +115,7 @@ curl https://example.com/wp-json/wp/v2/abilities/my-plugin/get-site-info
       }
     }
   },
-  "meta": {
-    "category": "site-info"
-  }
+  "meta": {}
 }
 ```
 
@@ -132,9 +127,9 @@ curl https://example.com/wp-json/wp/v2/abilities/my-plugin/get-site-info
 
 ### Arguments
 
-- `namespace` *(string)*: The namespace part of the ability name
-- `ability` *(string)*: The ability name part
-- `input` *(object)*: Input data for the ability as defined by its input schema
+- `namespace` _(string)_: The namespace part of the ability name.
+- `ability` _(string)_: The ability name part.
+- `input` _(integer|number|boolean|string|array|object|null)_: Optional input data for the ability as defined by its input schema.
 
 ### Example Request (No Input)
 
@@ -191,7 +186,11 @@ curl -u 'USERNAME:APPLICATION_PASSWORD' \
 
 The API returns standard WordPress REST API error responses with these common codes:
 
-- `ability_not_found` - The specified ability is not registered
-- `ability_invalid_input` - Input validation failed according to the ability's schema
-- `ability_invalid_permissions` - Current user lacks permission to execute the ability
-- `ability_execution_failed` - The ability callback returned a WP_Error
+- `ability_missing_input_schema` – the ability requires input but none was provided.
+- `ability_invalid_input` - input validation failed according to the ability's schema.
+- `ability_invalid_permissions` - current user lacks permission to execute the ability.
+- `ability_invalid_output` - output validation failed according to the ability's schema.
+- `ability_invalid_execute_callback` - the ability's execute callback is not callable.
+- `rest_ability_not_found` - the requested ability is not registered.
+- `rest_ability_invalid_method` - the requested HTTP method is not allowed for executing the selected ability.
+- `rest_ability_cannot_execute` - the ability cannot be executed due to insufficient permissions.

--- a/docs/5.rest-api.md
+++ b/docs/5.rest-api.md
@@ -2,6 +2,10 @@
 
 The WordPress Abilities API provides REST endpoints that allow external systems to discover and execute abilities via HTTP requests.
 
+## User access
+
+Access to all Abilities REST API endpoints requires an authenticated user (see the [Authentication](#authentication) section). Access to execute individual Abilities is restricted based on the `permission_callback()` of the Ability.
+
 ## Schema
 
 The Abilities API endpoints are available under the `/wp/v2/abilities` namespace.

--- a/docs/5.rest-api.md
+++ b/docs/5.rest-api.md
@@ -183,7 +183,7 @@ The Abilities API supports all WordPress REST API authentication methods:
 ### Using Application Passwords
 
 ```bash
-curl -H "Authorization: Bearer YOUR_APP_PASSWORD" \
+curl -u 'USERNAME:APPLICATION_PASSWORD' \
   https://example.com/wp-json/wp/v2/abilities
 ```
 

--- a/docs/5.rest-api.md
+++ b/docs/5.rest-api.md
@@ -1,0 +1,197 @@
+# 5. REST API Reference
+
+The WordPress Abilities API provides REST endpoints that allow external systems to discover and execute abilities via HTTP requests.
+
+## Schema
+
+The Abilities API endpoints are available under the `/wp/v2/abilities` namespace.
+
+### Ability Object
+
+Abilities are represented in JSON with the following structure:
+
+```json
+{
+  "name": "my-plugin/get-site-info",
+  "label": "Get Site Information",
+  "description": "Retrieves basic information about the WordPress site",
+  "input_schema": {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": false
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "name": {"type": "string"},
+      "url": {"type": "string", "format": "uri"}
+    }
+  },
+  "meta": {}
+}
+```
+
+## List Abilities
+
+### Definition
+
+`GET /wp/v2/abilities`
+
+### Arguments
+
+- `page` *(integer)*: Current page of the collection. Default: `1`
+- `per_page` *(integer)*: Maximum number of items to return per page. Default: `50`, Maximum: `100`
+
+### Example Request
+
+```bash
+curl https://example.com/wp-json/wp/v2/abilities
+```
+
+### Example Response
+
+```json
+[
+  {
+    "name": "my-plugin/get-site-info",
+    "label": "Get Site Information",
+    "description": "Retrieves basic information about the WordPress site",
+    "input_schema": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    },
+    "output_schema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Site name"
+        }
+      }
+    },
+    "meta": {}
+  }
+]
+```
+
+## Retrieve an Ability
+
+### Definition
+
+`GET /wp/v2/abilities/(?P<namespace>[a-z0-9-]+)/(?P<ability>[a-z0-9-]+)`
+
+### Arguments
+
+- `namespace` *(string)*: The namespace part of the ability name
+- `ability` *(string)*: The ability name part
+
+### Example Request
+
+```bash
+curl https://example.com/wp-json/wp/v2/abilities/my-plugin/get-site-info
+```
+
+### Example Response
+
+```json
+{
+  "name": "my-plugin/get-site-info",
+  "label": "Get Site Information",
+  "description": "Retrieves basic information about the WordPress site",
+  "input_schema": {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": false
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string",
+        "description": "Site name"
+      },
+      "url": {
+        "type": "string",
+        "format": "uri",
+        "description": "Site URL"
+      }
+    }
+  },
+  "meta": {
+    "category": "site-info"
+  }
+}
+```
+
+## Execute an Ability
+
+### Definition
+
+`POST /wp/v2/abilities/(?P<namespace>[a-z0-9-]+)/(?P<ability>[a-z0-9-]+)/run`
+
+### Arguments
+
+- `namespace` *(string)*: The namespace part of the ability name
+- `ability` *(string)*: The ability name part
+- `input` *(object)*: Input data for the ability as defined by its input schema
+
+### Example Request (No Input)
+
+```bash
+curl -X POST https://example.com/wp-json/wp/v2/abilities/my-plugin/get-site-info/run
+```
+
+### Example Request (With Input)
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"input":{"option_name":"blogname","option_value":"New Site Name"}}' \
+  https://example.com/wp-json/wp/v2/abilities/my-plugin/update-option/run
+```
+
+### Example Response (Success)
+
+```json
+{
+  "name": "My WordPress Site",
+  "url": "https://example.com"
+}
+```
+
+### Example Response (Error)
+
+```json
+{
+  "code": "ability_invalid_permissions",
+  "message": "Ability \"my-plugin/update-option\" does not have necessary permission.",
+  "data": {
+    "status": 403
+  }
+}
+```
+
+## Authentication
+
+The Abilities API supports all WordPress REST API authentication methods:
+
+- Cookie authentication (same-origin requests)
+- Application passwords (recommended for external access)
+- Custom authentication plugins
+
+### Using Application Passwords
+
+```bash
+curl -H "Authorization: Bearer YOUR_APP_PASSWORD" \
+  https://example.com/wp-json/wp/v2/abilities
+```
+
+## Error Responses
+
+The API returns standard WordPress REST API error responses with these common codes:
+
+- `ability_not_found` - The specified ability is not registered
+- `ability_invalid_input` - Input validation failed according to the ability's schema
+- `ability_invalid_permissions` - Current user lacks permission to execute the ability
+- `ability_execution_failed` - The ability callback returned a WP_Error

--- a/tests/unit/rest-api/wpRestAbilitiesRunController.php
+++ b/tests/unit/rest-api/wpRestAbilitiesRunController.php
@@ -366,7 +366,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 	/**
 	 * Test output validation against schema.
 	 * Note: When output validation fails in WP_Ability::execute(), it returns null,
-	 * which causes the REST controller to return 'rest_ability_execution_failed'.
+	 * which causes the REST controller to return 'ability_invalid_output'.
 	 */
 	public function test_output_validation(): void {
 		$request = new WP_REST_Request( 'POST', '/wp/v2/abilities/test/invalid-output/run' );


### PR DESCRIPTION
Closes #28.

Documents the available REST API endpoints and how to use them for registered abilities.

Covers three routes available:

- fetching all abilities
- fetching a single ability
- executing a single ability

This is a first pass generated and iterated with Claude Code.