### PR TITLE
fix: Wrong callback function for the Rest API endpoints.

### DIFF
--- a/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
@@ -60,7 +60,7 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'get_permissions_check' ),
 					'args'                => $this->get_collection_params(),
 				),
-				'schema' => array( $this, 'get_public_item_schema' ),
+				'schema' => array( $this, 'get_item_schema' ),
 			)
 		);
 
@@ -80,7 +80,7 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 					'callback'            => array( $this, 'get_item' ),
 					'permission_callback' => array( $this, 'get_permissions_check' ),
 				),
-				'schema' => array( $this, 'get_public_item_schema' ),
+				'schema' => array( $this, 'get_item_schema' ),
 			)
 		);
 	}


### PR DESCRIPTION
Fix the broken REST schema callback in the WP_REST_Abilities_List_Controller, as it is calling get_public_item_schema instead of get_item_schema.

Fixes https://github.com/WordPress/abilities-api/issues/78