### PR TITLE
fix: use link_header instead of add_link for pagination responses

### DIFF
--- a/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
@@ -128,13 +128,13 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 		if ( $page > 1 ) {
 			$prev_page = $page - 1;
 			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->add_link( 'prev', $prev_link );
+			$response->link_header( 'prev', $prev_link );
 		}
 
 		if ( $page < $max_pages ) {
 			$next_page = $page + 1;
 			$next_link = add_query_arg( 'page', $next_page, $base );
-			$response->add_link( 'next', $next_link );
+			$response->link_header( 'next', $next_link );
 		}
 
 		return $response;

--- a/tests/unit/rest-api/wpRestAbilitiesListController.php
+++ b/tests/unit/rest-api/wpRestAbilitiesListController.php
@@ -294,33 +294,40 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 	 * Test pagination links.
 	 */
 	public function test_pagination_links(): void {
-		// Test first page (should have 'next' link but no 'prev')
+		// Test first page (should have 'next' link header but no 'prev')
 		$request = new WP_REST_Request( 'GET', '/wp/v2/abilities' );
 		$request->set_param( 'per_page', 10 );
 		$request->set_param( 'page', 1 );
 		$response = $this->server->dispatch( $request );
 
-		$links = $response->get_links();
-		$this->assertArrayHasKey( 'next', $links );
-		$this->assertArrayNotHasKey( 'prev', $links );
+		$headers = $response->get_headers();
+		$link_header = $headers['Link'] ?? '';
 
-		// Test middle page (should have both 'next' and 'prev' links)
+		// Parse Link header for rel="next" and rel="prev"
+		$this->assertStringContainsString( 'rel="next"', $link_header );
+		$this->assertStringNotContainsString( 'rel="prev"', $link_header );
+
+		// Test middle page (should have both 'next' and 'prev' link headers)
 		$request->set_param( 'page', 3 );
 		$response = $this->server->dispatch( $request );
 
-		$links = $response->get_links();
-		$this->assertArrayHasKey( 'next', $links );
-		$this->assertArrayHasKey( 'prev', $links );
+		$headers = $response->get_headers();
+		$link_header = $headers['Link'] ?? '';
 
-		// Test last page (should have 'prev' link but no 'next')
+		$this->assertStringContainsString( 'rel="next"', $link_header );
+		$this->assertStringContainsString( 'rel="prev"', $link_header );
+
+		// Test last page (should have 'prev' link header but no 'next')
 		$total_abilities = count( wp_get_abilities() );
 		$last_page       = ceil( $total_abilities / 10 );
 		$request->set_param( 'page', $last_page );
 		$response = $this->server->dispatch( $request );
 
-		$links = $response->get_links();
-		$this->assertArrayNotHasKey( 'next', $links );
-		$this->assertArrayHasKey( 'prev', $links );
+		$headers = $response->get_headers();
+		$link_header = $headers['Link'] ?? '';
+
+		$this->assertStringNotContainsString( 'rel="next"', $link_header );
+		$this->assertStringContainsString( 'rel="prev"', $link_header );
 	}
 
 	/**


### PR DESCRIPTION
This PR uses `link_header` instead of `add_link` to add next/prev pagination links to keep the response as a pure array.

When using `add_link`, `_links` is added to the response body, converting it from an array to a JSON object like `{"0": {...}, "_links": {...}}`.

Note that this is a breaking fix from 0.1, though you would have only noticed if you set per_page to something low or had 50+ abilities. 

See also https://github.com/WordPress/abilities-api/pull/60#discussion_r2325014788.

## Testing Instructions

* Make sure that all unit tests pass
* Make a test GET request to `/wp/v2/abilities?per_page=1` and see that both `X-WP-Total` and `X-WP-TotalPages` are set
* Make a test GET request to `/wp/v2/abilities?per_page=1&page=2` and see that the response is an array of items