### PR TITLE
dev: Bump the PHPStan testing to PHP 8.4

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,7 +16,7 @@ parameters:
 		level: 8
 		phpVersion:
 			min: 70200
-			max: 80300
+			max: 80400
 		bootstrapFiles:
 				- abilities-api.php
 		paths:


### PR DESCRIPTION
PHP unit tests are run on PHP 8.4 so PHPStan should check in the context of 8.4 too.