### PR TITLE
Introduce `invoke_callback` helper method in `WP_Ability` class

### DIFF
--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -400,6 +400,24 @@ class WP_Ability {
 	}
 
 	/**
+	 * Invokes a callable, ensuring the input is passed through only if the input schema is defined.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param callable $callback The callable to invoke.
+	 * @param mixed    $input    Optional. The input data for the ability. Default `null`.
+	 * @return mixed The result of the callable execution.
+	 */
+	protected function invoke_callback( $callback, $input = null ) {
+		$args = array();
+		if ( ! empty( $this->get_input_schema() ) ) {
+			$args[] = $input;
+		}
+
+		return $callback( ...$args );
+	}
+
+	/**
 	 * Checks whether the ability has the necessary permissions.
 	 *
 	 * The input is validated against the input schema before it is passed to to permission callback.
@@ -415,11 +433,7 @@ class WP_Ability {
 			return $is_valid;
 		}
 
-		if ( empty( $this->get_input_schema() ) ) {
-			return call_user_func( $this->permission_callback );
-		}
-
-		return call_user_func( $this->permission_callback, $input );
+		return $this->invoke_callback( $this->permission_callback, $input );
 	}
 
 	/**
@@ -457,11 +471,7 @@ class WP_Ability {
 			);
 		}
 
-		if ( empty( $this->get_input_schema() ) ) {
-			return call_user_func( $this->execute_callback );
-		}
-
-		return call_user_func( $this->execute_callback, $input );
+		return $this->invoke_callback( $this->execute_callback, $input );
 	}
 
 	/**

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -408,7 +408,7 @@ class WP_Ability {
 	 * @param mixed    $input    Optional. The input data for the ability. Default `null`.
 	 * @return mixed The result of the callable execution.
 	 */
-	protected function invoke_callback( $callback, $input = null ) {
+	protected function invoke_callback( callable $callback, $input = null ) {
 		$args = array();
 		if ( ! empty( $this->get_input_schema() ) ) {
 			$args[] = $input;

--- a/tests/unit/abilities-api/wpAbility.php
+++ b/tests/unit/abilities-api/wpAbility.php
@@ -354,7 +354,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A instance method to be used as a callback in tests.
+	 * An instance method to be used as a callback in tests.
 	 *
 	 * @param string $input An input string.
 	 * @return int The length of the input string.

--- a/tests/unit/abilities-api/wpAbility.php
+++ b/tests/unit/abilities-api/wpAbility.php
@@ -344,6 +344,74 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A static method to be used as a callback in tests.
+	 *
+	 * @param string $input An input string.
+	 * @return int The length of the input string.
+	 */
+	public static function my_static_execute_callback( string $input ): int {
+		return strlen( $input );
+	}
+
+	/**
+	 * A instance method to be used as a callback in tests.
+	 *
+	 * @param string $input An input string.
+	 * @return int The length of the input string.
+	 */
+	public function my_instance_execute_callback( string $input ): int {
+		return strlen( $input );
+	}
+
+	/**
+	 * Data provider for testing different types of execute callbacks.
+	 */
+	public function data_execute_callback() {
+		return array(
+			'function name string'      => array(
+				'strlen',
+			),
+			'closure'                    => array(
+				static function ( string $input ): int {
+					return strlen( $input );
+				},
+			),
+			'static class method string' => array(
+				'Tests_Abilities_API_WpAbility::my_static_execute_callback',
+			),
+			'static class method array'  => array(
+				array( 'Tests_Abilities_API_WpAbility', 'my_static_execute_callback' ),
+			),
+			'object method'              => array(
+				array( $this, 'my_instance_execute_callback' ),
+			),
+		);
+	}
+
+	/**
+	 * Tests the execution of the ability with different types of callbacks.
+	 *
+	 * @dataProvider data_execute_callback
+	 */
+	public function test_execute_with_different_callbacks( $execute_callback) {
+		$args = array_merge(
+			self::$test_ability_properties,
+			array(
+				'input_schema'     => array(
+					'type'        => 'string',
+					'description' => 'Test input string.',
+					'required'    => true,
+				),
+				'execute_callback' => $execute_callback,
+			)
+		);
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+
+		$this->assertSame( 6, $ability->execute( 'hello!' ) );
+	}
+
+	/**
 	 * Tests the execution of the ability with no input.
 	 */
 	public function test_execute_no_input() {


### PR DESCRIPTION
This PR introduces a new `invoke_callback` helper method in the `WP_Ability` class to standardize callback invocation logic. The method handles whether to pass input parameters based on the presence of an input schema, replacing duplicated logic in the permission and execution callback methods. Additional test coverage was added to ensure that functionality continues to work the same way.

You can run tests locally with:

```bash
npm run test:php
```