### PR TITLE
docs: add Composer-managed installation instructions

### DIFF
--- a/docs/2.getting-started.md
+++ b/docs/2.getting-started.md
@@ -54,6 +54,12 @@ wp plugin install https://github.com/WordPress/abilities-api/releases/latest/dow
 }
 ```
 
+Then require the package in your project:
+
+```bash
+composer require wordpress/abilities-api
+```
+
 ### As a dependency
 
 Plugin authors and developers may wish to rely on the Abilities API as a dependency in their own projects, before it is merged into core. You can do that in one of the following ways.

--- a/docs/2.getting-started.md
+++ b/docs/2.getting-started.md
@@ -39,7 +39,7 @@ wp plugin install https://github.com/WordPress/abilities-api/releases/latest/dow
       "type": "vcs",
       "url": "https://github.com/WordPress/abilities-api.git"
     },
-    // ... other non WP-Packagist repositories.
+    // ... other non-WPackagist repositories.
   ],
   "extra": {
     "installer-paths": {

--- a/docs/2.getting-started.md
+++ b/docs/2.getting-started.md
@@ -29,13 +29,38 @@ wp plugin install https://github.com/WordPress/abilities-api/releases/latest/dow
 }
 ```
 
+#### In a Composer-managed WordPress installation
+
+```jsonc
+// composer.json
+{
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/WordPress/abilities-api.git"
+    },
+    // ... other non WP-Packagist repositories.
+  ],
+  "extra": {
+    "installer-paths": {
+      // This relative path should match your WordPress+Composer setup.
+      "wp-content/plugins/{$name}/": [
+          "type:wordpress-plugin"
+      ]
+      // .. other paths.
+    }
+  }
+  // ... rest of your composer.json.
+}
+```
+
 ### As a dependency
 
 Plugin authors and developers may wish to rely on the Abilities API as a dependency in their own projects, before it is merged into core. You can do that in one of the following ways.
 
-#### As a Plugin Dependency (Recommended)
+#### As a Plugin Dependency
 
-The best way to ensure the Abilities API is available for your plugins is to include it as one of your `Requires Plugins` in your [Plugin header](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/). For example:
+The easiest way to ensure the Abilities API is available for your plugins is to include it as one of your `Requires Plugins` in your [Plugin header](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/). For example:
 
 ```diff
 # my-plugin.php
@@ -49,7 +74,7 @@ The best way to ensure the Abilities API is available for your plugins is to inc
  */
 ```
 
-While this is enough to ensure the Abilities API is loaded before your plugin, if you need to ensure specific version requirements or provide users guidance on installing the plugin, you can use the methods described [later on](#checking-availability-with-code)
+While this is enough to prevent your plugin from being activated if the Abilities API plugin is not available, it does not install the plugin for you. If you need to ensure specific version requirements or provide users guidance on installing the plugin, you can use the methods described [later on](#checking-availability-with-code)
 
 #### As a Composer dependency
 

--- a/docs/2.getting-started.md
+++ b/docs/2.getting-started.md
@@ -45,7 +45,7 @@ wp plugin install https://github.com/WordPress/abilities-api/releases/latest/dow
     "installer-paths": {
       // This relative path should match your WordPress+Composer setup.
       "wp-content/plugins/{$name}/": [
-          "type:wordpress-plugin"
+        "type:wordpress-plugin"
       ]
       // .. other paths.
     }


### PR DESCRIPTION
## What

This PR adds docs on installing the plugin via Composer and clarifies the language around the intended usage of the plugin.

## Why

- Follow up to #66 , per https://make.wordpress.org/ai/2025/09/26/ai-chat-summary-18-september-2025/

   (props: Also reuses and expands on the example given in the PR description by @spenserhale  )