### PR TITLE
Prepare the branch for `v0.2.0` release

### DIFF
--- a/includes/abilities-api/class-wp-abilities-registry.php
+++ b/includes/abilities-api/class-wp-abilities-registry.php
@@ -87,7 +87,7 @@ final class WP_Abilities_Registry {
 		/**
 		 * Filters the ability arguments before they are validated and used to instantiate the ability.
 		 *
-		 * @since n.e.x.t
+		 * @since 0.2.0
 		 *
 		 * @param array<string,mixed> $args The arguments used to instantiate the ability.
 		 * @param string              $name The name of the ability, with its namespace.

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -436,7 +436,7 @@ class WP_Ability {
 		/**
 		 * Fires before an ability gets executed.
 		 *
-		 * @since n.e.x.t
+		 * @since 0.2.0
 		 *
 		 * @param string $ability_name The name of the ability.
 		 * @param mixed  $input        The input data for the ability.
@@ -456,7 +456,7 @@ class WP_Ability {
 		/**
 		 * Fires immediately after an ability finished executing.
 		 *
-		 * @since n.e.x.t
+		 * @since 0.2.0
 		 *
 		 * @param string $ability_name The name of the ability.
 		 * @param mixed  $input        The input data for the ability.

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -312,7 +312,7 @@ class WP_Ability {
 	 *
 	 * The input is validated against the input schema before it is passed to to permission callback.
 	 *
-	 * @since N.E.X.T
+	 * @since 0.2.0
 	 *
 	 * @param mixed $input Optional. The input data for permission checking. Default `null`.
 	 * @return bool|\WP_Error Whether the ability has the necessary permission.
@@ -335,7 +335,7 @@ class WP_Ability {
 	 *
 	 * The input is validated against the input schema before it is passed to to permission callback.
 	 *
-	 * @deprecated N.E.X.T Use check_permissions() instead.
+	 * @deprecated 0.2.0 Use check_permissions() instead.
 	 * @see WP_Ability::check_permissions()
 	 *
 	 * @since 0.1.0
@@ -344,7 +344,7 @@ class WP_Ability {
 	 * @return bool|\WP_Error Whether the ability has the necessary permission.
 	 */
 	public function has_permission( $input = null ) {
-		_deprecated_function( __METHOD__, 'N.E.X.T', 'WP_Ability::check_permissions()' );
+		_deprecated_function( __METHOD__, '0.2.0', 'WP_Ability::check_permissions()' );
 		return $this->check_permissions( $input );
 	}
 

--- a/tests/unit/abilities-api/wpAbility.php
+++ b/tests/unit/abilities-api/wpAbility.php
@@ -40,7 +40,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	 */
 	public function data_execute_input() {
 		return array(
-			'null input'     => array(
+			'null input'    => array(
 				array(
 					'type'        => array( 'null', 'integer' ),
 					'description' => 'The null or integer to convert to integer.',
@@ -52,7 +52,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 				null,
 				0,
 			),
-			'boolean input'  => array(
+			'boolean input' => array(
 				array(
 					'type'        => 'boolean',
 					'description' => 'The boolean to convert to integer.',
@@ -64,7 +64,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 				true,
 				1,
 			),
-			'integer input'  => array(
+			'integer input' => array(
 				array(
 					'type'        => 'integer',
 					'description' => 'The integer to add 5 to.',
@@ -76,7 +76,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 				2,
 				7,
 			),
-			'number input'   => array(
+			'number input'  => array(
 				array(
 					'type'        => 'number',
 					'description' => 'The floating number to round.',
@@ -88,7 +88,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 				2.7,
 				3,
 			),
-			'string input'   => array(
+			'string input'  => array(
 				array(
 					'type'        => 'string',
 					'description' => 'The string to measure the length of.',
@@ -100,7 +100,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 				'Hello world!',
 				12,
 			),
-			'object input'   => array(
+			'object input'  => array(
 				array(
 					'type'                 => 'object',
 					'description'          => 'An object containing two numbers to add.',
@@ -117,24 +117,27 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 						),
 					),
 					'additionalProperties' => false,
-			    ),
+				),
 				static function ( array $input ): int {
 					return $input['a'] + $input['b'];
 				},
-				array( 'a' => 2, 'b' => 3 ),
+				array(
+					'a' => 2,
+					'b' => 3,
+				),
 				5,
 			),
-			'array input'    => array(
+			'array input'   => array(
 				array(
 					'type'        => 'array',
 					'description' => 'An array containing two numbers to add.',
 					'required'    => true,
 					'minItems'    => 2,
-    				'maxItems'    => 2,
+					'maxItems'    => 2,
 					'items'       => array(
 						'type' => 'integer',
 					),
-			    ),
+				),
 				static function ( array $input ): int {
 					return $input[0] + $input[1];
 				},

--- a/tests/unit/rest-api/wpRestAbilitiesListController.php
+++ b/tests/unit/rest-api/wpRestAbilitiesListController.php
@@ -300,7 +300,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 		$request->set_param( 'page', 1 );
 		$response = $this->server->dispatch( $request );
 
-		$headers = $response->get_headers();
+		$headers     = $response->get_headers();
 		$link_header = $headers['Link'] ?? '';
 
 		// Parse Link header for rel="next" and rel="prev"
@@ -311,7 +311,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 		$request->set_param( 'page', 3 );
 		$response = $this->server->dispatch( $request );
 
-		$headers = $response->get_headers();
+		$headers     = $response->get_headers();
 		$link_header = $headers['Link'] ?? '';
 
 		$this->assertStringContainsString( 'rel="next"', $link_header );
@@ -323,7 +323,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 		$request->set_param( 'page', $last_page );
 		$response = $this->server->dispatch( $request );
 
-		$headers = $response->get_headers();
+		$headers     = $response->get_headers();
 		$link_header = $headers['Link'] ?? '';
 
 		$this->assertStringNotContainsString( 'rel="next"', $link_header );


### PR DESCRIPTION
This PR prepares the branch to release [v0.2.0 milestone](https://github.com/WordPress/abilities-api/milestone/3):
- Replaces `@since n.e.x.t` with `@since 0.2.0`
- Fixes some coding style incompatibilities with WordPress core detected during sync attempt tracked in https://github.com/WordPress/wordpress-develop/pull/9410.


