### PR TITLE
docs: Fix the variable name

### DIFF
--- a/docs/4.using-abilities.md
+++ b/docs/4.using-abilities.md
@@ -1,39 +1,131 @@
 ### 4. Using Abilities (`wp_get_ability`, `wp_get_abilities`)
 
+
+
+
 Once abilities are registered, they can be retrieved and executed using global functions from the Abilities API.
 
 **Getting a Specific Ability (`wp_get_ability`)**
+
+
+
+
 
 To get a single ability object by its name (namespace/ability-name):
 
 ```php
 /**
- * Retrieves a registered ability using Abilities API.
+ * Ret
+
+rieves a registered ability using Abilities API.
+
+
+
+
  *
  * @param string $name The name of the registered ability, with its namespace.
- * @return ?WP_Ability The registered ability instance, or null if it is not registered.
+
+
+
+
+ * @ret
+
+
+
+
+urn ?WP_Ability The registered ability instance, or null if it is not registered.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
  */
 function wp_get_ability( string $name ): ?WP_Ability
 
+
+
+
+
+
+
+
+
+
+
+
+
+
 // Example:
+
+
+
+
+
+
+
+
+
 $site_info_ability = wp_get_ability( 'my-plugin/get-site-info' );
+
+
+
+
+
+
+
+
 
 if ( $site_info_ability ) {
 	// Ability exists and is registered
-	$result = $site_info_ability->execute();
+
+
+
+	$site_info = $site_info_ability->execute();
 	if ( is_wp_error( $site_info ) ) {
+
 		// Handle WP_Error
+
 		echo 'Error: ' . $site_info->get_error_message();
+
+
 	} else {
 		// Use $site_info array
+
 		echo 'Site Name: ' . $site_info['name'];
 	}
 } else {
+
+
 	// Ability not found or not registered
+
 }
 ```
 
 **Getting All Registered Abilities (`wp_get_abilities`)**
+
+
+
+
+
+
+
+
 
 To get an array of all registered abilities:
 
@@ -45,10 +137,15 @@ To get an array of all registered abilities:
  */
 function wp_get_abilities(): array
 
+
 // Example: Get all registered abilities
+
 $all_abilities = wp_get_abilities();
 
+
 foreach ( $all_abilities as $name => $ability ) {
+
+
     echo 'Ability Name: ' . esc_html( $ability->get_name() ) . "\n";
     echo 'Label: ' . esc_html( $ability->get_label() ) . "\n";
     echo 'Description: ' . esc_html( $ability->get_description() ) . "\n";
@@ -58,7 +155,12 @@ foreach ( $all_abilities as $name => $ability ) {
 
 **Executing an Ability (`$ability->execute()`)**
 
+
+
 Once you have a `WP_Ability` object (usually from `wp_get_ability`), you execute it using the `execute()` method.
+
+
+
 
 ```php
 /**
@@ -69,8 +171,21 @@ Once you have a `WP_Ability` object (usually from `wp_get_ability`), you execute
  */
 // public function execute( $input = null )
 
+
+
+
 // Example 1: Ability with no input parameters
+
+
+
+
+
 $ability = wp_get_ability( 'my-plugin/get-site-info' );
+
+
+
+
+
 if ( $ability ) {
     $site_info = $ability->execute(); // No input required
     if ( is_wp_error( $site_info ) ) {
@@ -83,7 +198,46 @@ if ( $ability ) {
 }
 
 // Example 2: Ability with input parameters
+
+
+
+
+
+
+
+
+
+
+
+
 $ability = wp_get_ability( 'my-plugin/update-option' );
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 if ( $ability ) {
     $input = array(
         'option_name'  => 'blogname',
@@ -104,7 +258,15 @@ if ( $ability ) {
 }
 
 // Example 3: Ability with complex input validation
+
+
+
 $ability = wp_get_ability( 'my-plugin/send-email' );
+
+
+
+
+
 if ( $ability ) {
     $input = array(
         'to'      => 'user@example.com',
@@ -126,10 +288,18 @@ if ( $ability ) {
 
 **Checking Permissions (`$ability->has_permission()`)**
 
+
+
+
 Before executing an ability, you can check if the current user has permission:
 
 ```php
 $ability = wp_get_ability( 'my-plugin/update-option' );
+
+
+
+
+
 if ( $ability ) {
     $input = array(
         'option_name'  => 'blogname',
@@ -161,6 +331,8 @@ The `WP_Ability` class provides several getter methods to inspect ability proper
 
 ```php
 $ability = wp_get_ability( 'my-plugin/get-site-info' );
+
+
 if ( $ability ) {
     // Basic properties
     echo 'Name: ' . $ability->get_name() . "\n";
@@ -189,6 +361,8 @@ The Abilities API uses several error handling mechanisms:
 ```php
 $ability = wp_get_ability( 'my-plugin/some-ability' );
 
+
+
 if ( ! $ability ) {
     // Ability not registered
     echo 'Ability not found';
@@ -198,17 +372,46 @@ if ( ! $ability ) {
 $result = $ability->execute( $input );
 
 // Check for WP_Error (validation, permission, or callback errors)
+
+
+
 if ( is_wp_error( $result ) ) {
+
+
+
+
     echo 'WP_Error: ' . $result->get_error_message();
     return;
 }
 
 // Check for null result (permission denied, invalid callback, or validation failure)
+
 if ( is_null( $result ) ) {
     echo 'Execution returned null - check permissions and callback validity';
     return;
 }
 
 // Success - use the result
+
 // Process $result based on the ability's output schema
+
+
 ```
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Typo in the variable name caused confusion in the documentation. Changed `$result` to `$site_info` for consistency with later usage (e.g., `is_wp_error($site_info)` and `$site_info['name']`).