### PR TITLE
docs: Fix the variable name

### DIFF
--- a/docs/4.using-abilities.md
+++ b/docs/4.using-abilities.md
@@ -20,7 +20,7 @@ $site_info_ability = wp_get_ability( 'my-plugin/get-site-info' );
 
 if ( $site_info_ability ) {
 	// Ability exists and is registered
-	$result = $site_info_ability->execute();
+	$site_info = $site_info_ability->execute();
 	if ( is_wp_error( $site_info ) ) {
 		// Handle WP_Error
 		echo 'Error: ' . $site_info->get_error_message();


### PR DESCRIPTION
Typo in the variable name caused confusion in the documentation. Changed `$result` to `$site_info` for consistency with later usage (e.g., `is_wp_error($site_info)` and `$site_info['name'])`.