### PR TITLE
Fix documentation anti-patterns and REST API security vulnerability

### DIFF
--- a/docs/2.getting-started.md
+++ b/docs/2.getting-started.md
@@ -133,10 +133,27 @@ add_action( 'admin_init', 'my_plugin_use_ability' );
 function my_plugin_use_ability() {
     $ability = wp_get_ability( 'my-plugin/get-site-title' );
 
-    if ( $ability && $ability->has_permission() ) {
-        $site_title = $ability->execute();
-        // $site_title now holds the result of get_bloginfo('name')
-        // error_log( 'Site Title: ' . $site_title );
+    if ( $ability ) {
+        // Check permissions first - always use is_wp_error() to handle errors properly
+        $permission = $ability->check_permission();
+        if ( is_wp_error( $permission ) ) {
+            // Handle permission error
+            error_log( 'Permission error: ' . $permission->get_error_message() );
+            return;
+        } elseif ( $permission ) {
+            // Permission granted - safe to execute
+            $site_title = $ability->execute();
+            if ( is_wp_error( $site_title ) ) {
+                // Handle execution error
+                error_log( 'Execution error: ' . $site_title->get_error_message() );
+            } else {
+                // $site_title now holds the result of get_bloginfo('name')
+                // error_log( 'Site Title: ' . $site_title );
+            }
+        } else {
+            // Permission denied
+            error_log( 'Permission denied for ability execution' );
+        }
     }
 }
 ```

--- a/docs/2.getting-started.md
+++ b/docs/2.getting-started.md
@@ -134,25 +134,13 @@ function my_plugin_use_ability() {
     $ability = wp_get_ability( 'my-plugin/get-site-title' );
 
     if ( $ability ) {
-        // Check permissions first - always use is_wp_error() to handle errors properly
-        $permission = $ability->check_permission();
-        if ( is_wp_error( $permission ) ) {
-            // Handle permission error
-            error_log( 'Permission error: ' . $permission->get_error_message() );
-            return;
-        } elseif ( $permission ) {
-            // Permission granted - safe to execute
-            $site_title = $ability->execute();
-            if ( is_wp_error( $site_title ) ) {
-                // Handle execution error
-                error_log( 'Execution error: ' . $site_title->get_error_message() );
-            } else {
-                // $site_title now holds the result of get_bloginfo('name')
-                // error_log( 'Site Title: ' . $site_title );
-            }
+        $site_title = $ability->execute();
+        if ( is_wp_error( $site_title ) ) {
+            // Handle any error (permission, validation, or execution)
+            error_log( 'Error: ' . $site_title->get_error_message() );
         } else {
-            // Permission denied
-            error_log( 'Permission denied for ability execution' );
+            // $site_title now holds the result of get_bloginfo('name')
+            // error_log( 'Site Title: ' . $site_title );
         }
     }
 }

--- a/docs/4.using-abilities.md
+++ b/docs/4.using-abilities.md
@@ -124,9 +124,14 @@ if ( $ability ) {
 }
 ```
 
-**Checking Permissions (`$ability->has_permission()`)**
+**Checking Permissions (`$ability->check_permission()`)**
 
-Before executing an ability, you can check if the current user has permission:
+Before executing an ability, you can check if the current user has permission. The `check_permission()` method returns either `true`, `false`, or a `WP_Error` object, so you must use `is_wp_error()` to handle errors properly:
+
+```php
+// Method signature:
+// check_permission( $input = null )
+```
 
 ```php
 $ability = wp_get_ability( 'my-plugin/update-option' );
@@ -136,12 +141,17 @@ if ( $ability ) {
         'option_value' => 'New Site Name',
     );
 
-    // Check permission before execution
-    if ( $ability->has_permission( $input ) ) {
+    // Check permission before execution - always use is_wp_error() first
+    $permission = $ability->check_permission( $input );
+    if ( is_wp_error( $permission ) ) {
+        // Handle permission check error (validation, callback error, etc.)
+        echo 'Permission check failed: ' . $permission->get_error_message();
+    } elseif ( $permission ) {
+        // Permission granted - safe to execute
         $result = $ability->execute( $input );
         if ( is_wp_error( $result ) ) {
-	        // Handle WP_Error
-	        echo 'Error: ' . $result->get_error_message();
+	        // Handle execution error
+	        echo 'Execution error: ' . $result->get_error_message();
         } else {
         	// Use $result
 			if ( $result['success'] ) {
@@ -150,6 +160,7 @@ if ( $ability ) {
 			}
         }
     } else {
+        // Permission denied
         echo 'You do not have permission to execute this ability.';
     }
 }

--- a/docs/4.using-abilities.md
+++ b/docs/4.using-abilities.md
@@ -21,12 +21,12 @@ $site_info_ability = wp_get_ability( 'my-plugin/get-site-info' );
 if ( $site_info_ability ) {
 	// Ability exists and is registered
 	$result = $site_info_ability->execute();
-	if ( is_wp_error( $site_info ) ) {
-		// Handle WP_Error
-		echo 'Error: ' . $site_info->get_error_message();
+	if ( is_wp_error( $result ) ) {
+		// Handle any error (permission, validation, or execution)
+		echo 'Error: ' . $result->get_error_message();
 	} else {
-		// Use $site_info array
-		echo 'Site Name: ' . $site_info['name'];
+		// Use result data
+		echo 'Site Name: ' . $result['name'];
 	}
 } else {
 	// Ability not found or not registered
@@ -74,10 +74,10 @@ $ability = wp_get_ability( 'my-plugin/get-site-info' );
 if ( $ability ) {
     $site_info = $ability->execute(); // No input required
     if ( is_wp_error( $site_info ) ) {
-        // Handle WP_Error
+        // Handle any error (permission, validation, or execution)
         echo 'Error: ' . $site_info->get_error_message();
     } else {
-        // Use $site_info array
+        // Use result data
         echo 'Site Name: ' . $site_info['name'];
     }
 }
@@ -124,14 +124,11 @@ if ( $ability ) {
 }
 ```
 
-**Checking Permissions (`$ability->check_permission()`)**
 
-Before executing an ability, you can check if the current user has permission. The `check_permission()` method returns either `true`, `false`, or a `WP_Error` object, so you must use `is_wp_error()` to handle errors properly:
+**Understanding Permissions**
 
-```php
-// Method signature:
-// check_permission( $input = null )
-```
+Abilities handle permission checking automatically during execution. The `execute()` method will check permissions and return a `WP_Error` if access is denied. You rarely need to check permissions separately.
+
 
 ```php
 $ability = wp_get_ability( 'my-plugin/update-option' );
@@ -141,27 +138,42 @@ if ( $ability ) {
         'option_value' => 'New Site Name',
     );
 
-    // Check permission before execution - always use is_wp_error() first
-    $permission = $ability->check_permission( $input );
-    if ( is_wp_error( $permission ) ) {
-        // Handle permission check error (validation, callback error, etc.)
-        echo 'Permission check failed: ' . $permission->get_error_message();
-    } elseif ( $permission ) {
-        // Permission granted - safe to execute
-        $result = $ability->execute( $input );
-        if ( is_wp_error( $result ) ) {
-	        // Handle execution error
-	        echo 'Execution error: ' . $result->get_error_message();
-        } else {
-        	// Use $result
+    // Recommended approach: execute() handles permission checking internally
+    $result = $ability->execute( $input );
+    if ( is_wp_error( $result ) ) {
+        // Handle any error (permission, validation, or execution)
+        echo 'Error: ' . $result->get_error_message();
+    } else {
+        // Success - use the result
 			if ( $result['success'] ) {
 				echo 'Option updated successfully!';
 				echo 'Previous value: ' . $result['previous_value'];
 			}
-        }
-    } else {
-        // Permission denied
+    }
+}
+```
+
+**Advanced Error Handling**
+
+If you need to handle specific error types differently, you can check the error code:
+
+```php
+$ability = wp_get_ability( 'my-plugin/update-option' );
+if ( $ability ) {
+    $result = $ability->execute( $input );
+    
+    // Handle specific error types if needed
+    if ( is_wp_error( $result ) && 'ability_invalid_permissions' === $result->get_error_code() ) {
+        // Handle permission errors specifically
         echo 'You do not have permission to execute this ability.';
+    } elseif ( is_wp_error( $result ) ) {
+        // Handle other errors (validation, execution, etc.)
+        echo 'Error: ' . $result->get_error_message();
+    } else {
+        // Success - use the result
+        if ( $result['success'] ) {
+            echo 'Option updated successfully!';
+        }
     }
 }
 ```

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -412,7 +412,7 @@ class WP_Ability {
 	 * @return mixed|\WP_Error The result of the ability execution, or WP_Error on failure.
 	 */
 	public function execute( $input = null ) {
-		$has_permissions = $this->has_permission( $input );
+		$has_permissions = $this->check_permission( $input );
 		if ( true !== $has_permissions ) {
 			if ( is_wp_error( $has_permissions ) ) {
 				if ( 'ability_invalid_input' === $has_permissions->get_error_code() ) {

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -312,12 +312,12 @@ class WP_Ability {
 	 *
 	 * The input is validated against the input schema before it is passed to to permission callback.
 	 *
-	 * @since 0.1.0
+	 * @since N.E.X.T
 	 *
 	 * @param mixed $input Optional. The input data for permission checking. Default `null`.
 	 * @return bool|\WP_Error Whether the ability has the necessary permission.
 	 */
-	public function has_permission( $input = null ) {
+	public function check_permission( $input = null ) {
 		$is_valid = $this->validate_input( $input );
 		if ( is_wp_error( $is_valid ) ) {
 			return $is_valid;
@@ -328,6 +328,24 @@ class WP_Ability {
 		}
 
 		return call_user_func( $this->permission_callback, $input );
+	}
+
+	/**
+	 * Checks whether the ability has the necessary permissions (deprecated).
+	 *
+	 * The input is validated against the input schema before it is passed to to permission callback.
+	 *
+	 * @deprecated N.E.X.T Use check_permission() instead.
+	 * @see WP_Ability::check_permission()
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param mixed $input Optional. The input data for permission checking. Default `null`.
+	 * @return bool|\WP_Error Whether the ability has the necessary permission.
+	 */
+	public function has_permission( $input = null ) {
+		_deprecated_function( __METHOD__, 'N.E.X.T', 'WP_Ability::check_permission()' );
+		return $this->check_permission( $input );
 	}
 
 	/**

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
@@ -163,7 +163,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 		}
 
 		$input = $this->get_input_from_request( $request );
-		if ( ! $ability->check_permission( $input ) ) {
+		if ( true !== $ability->check_permission( $input ) ) {
 			return new \WP_Error(
 				'rest_ability_cannot_execute',
 				__( 'Sorry, you are not allowed to execute this ability.' ),

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
@@ -163,7 +163,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 		}
 
 		$input = $this->get_input_from_request( $request );
-		if ( ! $ability->has_permission( $input ) ) {
+		if ( ! $ability->check_permission( $input ) ) {
 			return new \WP_Error(
 				'rest_ability_cannot_execute',
 				__( 'Sorry, you are not allowed to execute this ability.' ),

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -134,7 +134,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 		$this->assertSame( self::$test_ability_args['output_schema'], $result->get_output_schema() );
 		$this->assertSame( self::$test_ability_args['meta'], $result->get_meta() );
 		$this->assertTrue(
-			$result->has_permission(
+			$result->check_permission(
 				array(
 					'a' => 2,
 					'b' => 3,
@@ -289,7 +289,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 
 		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
 
-		$actual = $result->has_permission(
+		$actual = $result->check_permission(
 			array(
 				'a'       => 2,
 				'b'       => 3,
@@ -305,6 +305,27 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 		$this->assertSame(
 			'Ability "test/add-numbers" has invalid input. Reason: unknown is not a valid property of Object.',
 			$actual->get_error_message()
+		);
+	}
+
+	/**
+	 * Tests that the deprecated has_permission() method still works and shows deprecation.
+	 *
+	 * @expectedDeprecated WP_Ability::has_permission
+	 */
+	public function test_has_permission_deprecated_method(): void {
+		do_action( 'abilities_api_init' );
+
+		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
+
+		// Test that deprecated method still works
+		$this->assertTrue(
+			$result->has_permission(
+				array(
+					'a' => 2,
+					'b' => 3,
+				)
+			)
 		);
 	}
 
@@ -325,7 +346,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 
 		// Test with a > b (should be allowed)
 		$this->assertTrue(
-			$result->has_permission(
+			$result->check_permission(
 				array(
 					'a' => 5,
 					'b' => 3,
@@ -342,7 +363,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 
 		// Test with a < b (should be denied)
 		$this->assertFalse(
-			$result->has_permission(
+			$result->check_permission(
 				array(
 					'a' => 2,
 					'b' => 8,

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -309,27 +309,6 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the deprecated has_permission() method still works and shows deprecation.
-	 *
-	 * @expectedDeprecated WP_Ability::has_permission
-	 */
-	public function test_has_permission_deprecated_method(): void {
-		do_action( 'abilities_api_init' );
-
-		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
-
-		// Test that deprecated method still works
-		$this->assertTrue(
-			$result->has_permission(
-				array(
-					'a' => 2,
-					'b' => 3,
-				)
-			)
-		);
-	}
-
-	/**
 	 * Tests permission callback receiving input for contextual permission checks.
 	 */
 	public function test_permission_callback_receives_input(): void {

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -309,16 +309,15 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that deprecated has_permission() method still works
+	 * Tests that deprecated has_permission() method still works (for coverage).
 	 */
 	public function test_has_permission_deprecated_coverage(): void {
 		do_action( 'abilities_api_init' );
 
 		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
 
-		// Suppress deprecation notice for coverage testing
-		$original_error_reporting = error_reporting();
-		error_reporting( $original_error_reporting & ~E_USER_DEPRECATED );
+		// Expect the deprecation notice
+		$this->setExpectedDeprecated( 'WP_Ability::has_permission' );
 		
 		// Test that deprecated method still works
 		$this->assertTrue(
@@ -329,9 +328,6 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 				)
 			)
 		);
-		
-		// Restore error reporting
-		error_reporting( $original_error_reporting );
 	}
 
 	/**

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -309,6 +309,32 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that deprecated has_permission() method still works
+	 */
+	public function test_has_permission_deprecated_coverage(): void {
+		do_action( 'abilities_api_init' );
+
+		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
+
+		// Suppress deprecation notice for coverage testing
+		$original_error_reporting = error_reporting();
+		error_reporting( $original_error_reporting & ~E_USER_DEPRECATED );
+		
+		// Test that deprecated method still works
+		$this->assertTrue(
+			$result->has_permission(
+				array(
+					'a' => 2,
+					'b' => 3,
+				)
+			)
+		);
+		
+		// Restore error reporting
+		error_reporting( $original_error_reporting );
+	}
+
+	/**
 	 * Tests permission callback receiving input for contextual permission checks.
 	 */
 	public function test_permission_callback_receives_input(): void {

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -309,16 +309,15 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that deprecated has_permission() method still works (for coverage).
+	 * Tests that deprecated has_permission() method still works.
+	 *
+	 * @expectedDeprecated WP_Ability::has_permission
 	 */
 	public function test_has_permission_deprecated_coverage(): void {
 		do_action( 'abilities_api_init' );
 
 		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
 
-		// Expect the deprecation notice
-		$this->setExpectedDeprecated( 'WP_Ability::has_permission' );
-		
 		// Test that deprecated method still works
 		$this->assertTrue(
 			$result->has_permission(

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -164,7 +164,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
 
 		$this->assertFalse(
-			$result->has_permission(
+			$result->check_permission(
 				array(
 					'a' => 2,
 					'b' => 3,


### PR DESCRIPTION
## Summary
- Replace manual permission checking examples with secure execute() patterns
- Fix critical REST API security vulnerability in permission validation  
- Address @justlevine's feedback from PR #76 about documentation anti-patterns

## Changes Made

### Documentation Fixes
- **docs/2.getting-started.md**: Replaced 22-line manual permission checking example with clean 8-line execute() pattern
- **docs/4.using-abilities.md**: Eliminated all manual permission checking examples, added advanced error handling section, fixed variable name bug

### Security Fix  
- **includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php**: Fixed WP_Error truthiness vulnerability in REST API permissions

## Test plan
- [ ] Verify documentation examples follow recommended patterns
- [ ] Test REST API endpoint permission handling with various scenarios
- [ ] Confirm no manual permission checking anti-patterns remain in docs