### PR TITLE
docs: fix wp_register_ability() args not marked as required.

### DIFF
--- a/includes/abilities-api.php
+++ b/includes/abilities-api.php
@@ -29,10 +29,10 @@ declare( strict_types = 1 );
  * @return ?\WP_Ability An instance of registered ability on success, null on failure.
  *
  * @phpstan-param array{
- *   label?: string,
- *   description?: string,
- *   execute_callback?: callable( mixed $input= ): (mixed|\WP_Error),
- *   permission_callback?: callable( mixed $input= ): (bool|\WP_Error),
+ *   label: string,
+ *   description: string,
+ *   execute_callback: callable( mixed $input= ): (mixed|\WP_Error),
+ *   permission_callback: callable( mixed $input= ): (bool|\WP_Error),
  *   input_schema?: array<string,mixed>,
  *   output_schema?: array<string,mixed>,
  *   meta?: array<string,mixed>,


### PR DESCRIPTION
## What

This PR fixes the `@phpstan-param` type annotations for the required `label`, `description`, `execute_callback`, and `permission_callback` `$args` on `wp_register_ability()`

This PR was authored by @johnbillion on https://github.com/justlevine/abilities-api/pull/6, but I didn't see it before the upstream PR got merged. All I did was cherrypick it onto truck.

## Why

Per John

> We can help PHPStan users by making these elements required. It doesn't affect the guard conditions in WP_Ability::prepare_properties() because the args array isn't documented there.


