### PR TITLE
Fix backwards compatibility with WP_REST_Request API

### DIFF
--- a/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
@@ -105,7 +105,7 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 		$total_abilities = count( $abilities );
 		$max_pages       = ceil( $total_abilities / $per_page );
 
-		if ( $request->is_method( 'HEAD' ) ) {
+		if ( $request->get_method() === 'HEAD' ) {
 			$response = new \WP_REST_Response( array() );
 		} else {
 			$abilities = array_slice( $abilities, $offset, $per_page );


### PR DESCRIPTION
## Summary
Replaces `is_method()` with `get_method()` in `WP_REST_Abilities_List_Controller` to fix backwards compatibility with earlier WordPress versions where `is_method()` does not exist on `WP_REST_Request`.

## Changes
- Changed `$request->is_method( 'HEAD' )` to `$request->get_method() === 'HEAD'` in `class-wp-rest-abilities-list-controller.php:108`

🤖 Generated with [Claude Code](https://claude.com/claude-code)