### PR TITLE
Proposal: Add ability anotations

### DIFF
--- a/includes/abilities-api.php
+++ b/includes/abilities-api.php
@@ -25,7 +25,7 @@ declare( strict_types = 1 );
  *                                  alphanumeric characters, dashes and the forward slash.
  * @param array<string,mixed> $args An associative array of arguments for the ability. This should include
  *                                  `label`, `description`, `input_schema`, `output_schema`, `execute_callback`,
- *                                  `permission_callback`, `meta`, and `ability_class`.
+ *                                  `permission_callback`, `annotations`, `meta`, and `ability_class`.
  * @return ?\WP_Ability An instance of registered ability on success, null on failure.
  *
  * @phpstan-param array{
@@ -35,6 +35,7 @@ declare( strict_types = 1 );
  *   permission_callback?: callable( mixed $input= ): (bool|\WP_Error),
  *   input_schema?: array<string,mixed>,
  *   output_schema?: array<string,mixed>,
+ *   annotations?: array<string,mixed>,
  *   meta?: array<string,mixed>,
  *   ability_class?: class-string<\WP_Ability>,
  *   ...<string, mixed>

--- a/includes/abilities-api/class-wp-abilities-registry.php
+++ b/includes/abilities-api/class-wp-abilities-registry.php
@@ -57,6 +57,7 @@ final class WP_Abilities_Registry {
 	 *   permission_callback?: callable( mixed $input= ): (bool|\WP_Error),
 	 *   input_schema?: array<string,mixed>,
 	 *   output_schema?: array<string,mixed>,
+	 *   annotations?: array<string,mixed>,
 	 *   meta?: array<string,mixed>,
 	 *   ability_class?: class-string<\WP_Ability>,
 	 *   ...<string, mixed>

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -30,7 +30,7 @@ class WP_Ability {
 		// Instructions on how to use the ability.
 		'instructions' => '',
 		// If true, the ability does not modify its environment.
-		'read_only'    => false,
+		'readonly'     => false,
 		/*
 		 * If true, the ability may perform destructive updates to its environment.
 		 * If false, the ability performs only additive updates.

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -19,6 +19,30 @@ declare( strict_types = 1 );
  * @see WP_Abilities_Registry
  */
 class WP_Ability {
+	/**
+	 * The default ability annotations.
+	 * They are not guaranteed to provide a faithful description of ability behavior.
+	 *
+	 * @since n.e.x.t
+	 * @var array<string,(bool|string)>
+	 */
+	const DEFAULT_ANNOTATIONS = array(
+		// An instruction on how to use the ability.
+		'instruction' => '',
+		// If true, the ability does not modify its environment.
+		'read_only'   => false,
+		/*
+		 * If true, the ability may perform destructive updates to its environment.
+		 * If false, the ability performs only additive updates.
+		 */
+		'destructive' => true,
+		/*
+		 * If true, calling the ability repeatedly with the same arguments will have no additional effect
+		 * on its environment.
+		 */
+		'idempotent'  => false,
+
+	);
 
 	/**
 	 * The name of the ability, with its namespace.
@@ -78,6 +102,14 @@ class WP_Ability {
 	protected $permission_callback;
 
 	/**
+	 * The ability annotations.
+	 *
+	 * @since n.e.x.t
+	 * @var array<string,(bool|string)>
+	 */
+	protected $annotations = self::DEFAULT_ANNOTATIONS;
+
+	/**
 	 * The optional ability metadata.
 	 *
 	 * @since 0.1.0
@@ -99,7 +131,7 @@ class WP_Ability {
 	 * @param string              $name The name of the ability, with its namespace.
 	 * @param array<string,mixed> $args An associative array of arguments for the ability. This should
 	 *                                  include `label`, `description`, `input_schema`, `output_schema`,
-	 *                                  `execute_callback`, `permission_callback`, and `meta`.
+	 *                                  `execute_callback`, `permission_callback`, `annotations`, and `meta`.
 	 */
 	public function __construct( string $name, array $args ) {
 		$this->name = $name;
@@ -190,6 +222,12 @@ class WP_Ability {
 			);
 		}
 
+		if ( isset( $args['annotations']) && ! is_array( $args['annotations'] ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'The ability properties should provide a valid `annotations` array.' )
+			);
+		}
+
 		if ( isset( $args['meta'] ) && ! is_array( $args['meta'] ) ) {
 			throw new \InvalidArgumentException(
 				esc_html__( 'The ability properties should provide a valid `meta` array.' )
@@ -253,6 +291,17 @@ class WP_Ability {
 	 */
 	public function get_output_schema(): array {
 		return $this->output_schema;
+	}
+
+	/**
+	 * Retrieves the annotations for the ability.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array<string,(bool|string)> The annotations for the ability.
+	 */
+	public function get_annotations(): array {
+		return $this->annotations;
 	}
 
 	/**

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -235,9 +235,10 @@ class WP_Ability {
 		}
 
 		// Set defaults for optional args.
-		if ( ! isset( $args['annotations'] ) ) {
-			$args['annotations'] = static::$default_annotations;
-		}
+		$args['annotations'] = wp_parse_args(
+			$args['annotations'] ?? array(),
+			static::$default_annotations
+		);
 
 		return $args;
 	}

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -26,7 +26,7 @@ class WP_Ability {
 	 * @since n.e.x.t
 	 * @var array<string,(bool|string)>
 	 */
-	const DEFAULT_ANNOTATIONS = array(
+	protected static $default_annotations = array(
 		// An instruction on how to use the ability.
 		'instruction' => '',
 		// If true, the ability does not modify its environment.
@@ -41,7 +41,6 @@ class WP_Ability {
 		 * on its environment.
 		 */
 		'idempotent'  => false,
-
 	);
 
 	/**
@@ -107,7 +106,7 @@ class WP_Ability {
 	 * @since n.e.x.t
 	 * @var array<string,(bool|string)>
 	 */
-	protected $annotations = self::DEFAULT_ANNOTATIONS;
+	protected $annotations = array();
 
 	/**
 	 * The optional ability metadata.
@@ -179,6 +178,7 @@ class WP_Ability {
 	 *   permission_callback: callable( mixed $input= ): (bool|\WP_Error),
 	 *   input_schema?: array<string,mixed>,
 	 *   output_schema?: array<string,mixed>,
+	 *   annotations?: array<string,mixed>,
 	 *   meta?: array<string,mixed>,
 	 *   ...<string, mixed>,
 	 * } $args
@@ -222,7 +222,7 @@ class WP_Ability {
 			);
 		}
 
-		if ( isset( $args['annotations']) && ! is_array( $args['annotations'] ) ) {
+		if ( isset( $args['annotations'] ) && ! is_array( $args['annotations'] ) ) {
 			throw new \InvalidArgumentException(
 				esc_html__( 'The ability properties should provide a valid `annotations` array.' )
 			);
@@ -232,6 +232,11 @@ class WP_Ability {
 			throw new \InvalidArgumentException(
 				esc_html__( 'The ability properties should provide a valid `meta` array.' )
 			);
+		}
+
+		// Set defaults for optional args.
+		if ( ! isset( $args['annotations'] ) ) {
+			$args['annotations'] = static::$default_annotations;
 		}
 
 		return $args;

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -27,20 +27,20 @@ class WP_Ability {
 	 * @var array<string,(bool|string)>
 	 */
 	protected static $default_annotations = array(
-		// An instruction on how to use the ability.
-		'instruction' => '',
+		// Instructions on how to use the ability.
+		'instructions' => '',
 		// If true, the ability does not modify its environment.
-		'read_only'   => false,
+		'read_only'    => false,
 		/*
 		 * If true, the ability may perform destructive updates to its environment.
 		 * If false, the ability performs only additive updates.
 		 */
-		'destructive' => true,
+		'destructive'  => true,
 		/*
 		 * If true, calling the ability repeatedly with the same arguments will have no additional effect
 		 * on its environment.
 		 */
-		'idempotent'  => false,
+		'idempotent'   => false,
 	);
 
 	/**

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
@@ -191,6 +191,7 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 			'description'   => $ability->get_description(),
 			'input_schema'  => $ability->get_input_schema(),
 			'output_schema' => $ability->get_output_schema(),
+			'annotations'   => $ability->get_annotations(),
 			'meta'          => $ability->get_meta(),
 		);
 
@@ -260,6 +261,12 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 				),
 				'output_schema' => array(
 					'description' => __( 'JSON Schema for the ability output.' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'annotations'   => array(
+					'description' => __( 'Annotations for the ability.' ),
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
@@ -54,8 +54,8 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 					),
 				),
 
-				// TODO: We register ALLMETHODS because at route registration time, we don't know
-				// which abilities exist or their types (resource vs tool). This is due to WordPress
+				// TODO: We register ALLMETHODS because at route registration time, we don't know which abilities
+				// exist or their annotations (`destructive`, `idempotent`, `read_only`). This is due to WordPress
 				// load order - routes are registered early, before plugins have registered their abilities.
 				// This approach works but could be improved with lazy route registration or a different
 				// architecture that allows type-specific routes after abilities are registered.
@@ -90,23 +90,23 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 			);
 		}
 
-		// Check if the HTTP method matches the ability type.
-		$meta   = $ability->get_meta();
-		$type   = isset( $meta['type'] ) ? $meta['type'] : 'tool';
-		$method = $request->get_method();
+		// Check if the HTTP method matches the ability annotations.
+		$annotations  = $ability->get_annotations();
+		$is_read_only = ! empty( $annotations['read_only'] );
+		$method       = $request->get_method();
 
-		if ( 'resource' === $type && 'GET' !== $method ) {
+		if ( $is_read_only && 'GET' !== $method ) {
 			return new \WP_Error(
 				'rest_ability_invalid_method',
-				__( 'Resource abilities require GET method.' ),
+				__( 'Read only abilities require GET method.' ),
 				array( 'status' => 405 )
 			);
 		}
 
-		if ( 'tool' === $type && 'POST' !== $method ) {
+		if ( ! $is_read_only && 'POST' !== $method ) {
 			return new \WP_Error(
 				'rest_ability_invalid_method',
-				__( 'Tool abilities require POST method.' ),
+				__( 'Abilities that perform updates require POST method.' ),
 				array( 'status' => 405 )
 			);
 		}

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
@@ -55,7 +55,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 				),
 
 				// TODO: We register ALLMETHODS because at route registration time, we don't know which abilities
-				// exist or their annotations (`destructive`, `idempotent`, `read_only`). This is due to WordPress
+				// exist or their annotations (`destructive`, `idempotent`, `readonly`). This is due to WordPress
 				// load order - routes are registered early, before plugins have registered their abilities.
 				// This approach works but could be improved with lazy route registration or a different
 				// architecture that allows type-specific routes after abilities are registered.
@@ -91,19 +91,19 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 		}
 
 		// Check if the HTTP method matches the ability annotations.
-		$annotations  = $ability->get_annotations();
-		$is_read_only = ! empty( $annotations['read_only'] );
-		$method       = $request->get_method();
+		$annotations = $ability->get_annotations();
+		$is_readonly = ! empty( $annotations['readonly'] );
+		$method      = $request->get_method();
 
-		if ( $is_read_only && 'GET' !== $method ) {
+		if ( $is_readonly && 'GET' !== $method ) {
 			return new \WP_Error(
 				'rest_ability_invalid_method',
-				__( 'Read only abilities require GET method.' ),
+				__( 'Read-only abilities require GET method.' ),
 				array( 'status' => 405 )
 			);
 		}
 
-		if ( ! $is_read_only && 'POST' !== $method ) {
+		if ( ! $is_readonly && 'POST' !== $method ) {
 			return new \WP_Error(
 				'rest_ability_invalid_method',
 				__( 'Abilities that perform updates require POST method.' ),

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -99,11 +99,11 @@ if ( ability ) {
 
 Executes an ability with optional input parameters. The HTTP method is automatically determined based on the ability's annotations:
 
-- `read_only` abilities use GET (read-only operations)
+- `readonly` abilities use GET (read-only operations)
 - regular abilities use POST (write operations)
 
 ```javascript
-// Execute a read only ability (GET)
+// Execute a read-only ability (GET)
 const data = await executeAbility( 'my-plugin/get-data', {
   id: 123,
 } );

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -28,13 +28,13 @@ const { getAbilities, getAbility, executeAbility } = wp.abilities;
 const abilities = await getAbilities();
 
 // Get a specific ability
-const ability = await getAbility('my-plugin/my-ability');
+const ability = await getAbility( 'my-plugin/my-ability' );
 
 // Execute an ability
-const result = await executeAbility('my-plugin/my-ability', {
+const result = await executeAbility( 'my-plugin/my-ability', {
   param1: 'value1',
   param2: 'value2',
-});
+} );
 ```
 
 ### Using with React and WordPress Data
@@ -47,12 +47,12 @@ import { store as abilitiesStore } from '@wordpress/abilities';
 
 function MyComponent() {
   const abilities = useSelect(
-    (select) => select(abilitiesStore).getAbilities(),
+    ( select ) => select( abilitiesStore ).getAbilities(),
     []
   );
 
   const specificAbility = useSelect(
-    (select) => select(abilitiesStore).getAbility('my-plugin/my-ability'),
+    ( select ) => select( abilitiesStore ).getAbility( 'my-plugin/my-ability' ),
     []
   );
 
@@ -60,11 +60,11 @@ function MyComponent() {
     <div>
       <h2>All Abilities</h2>
       <ul>
-        {abilities.map((ability) => (
-          <li key={ability.name}>
-            <strong>{ability.label}</strong>: {ability.description}
+        { abilities.map( ( ability ) => (
+          <li key={ ability.name }>
+            <strong>{ ability.label }</strong>: { ability.description }
           </li>
-        ))}
+        ) ) }
       </ul>
     </div>
   );
@@ -81,7 +81,7 @@ Returns all registered abilities. Automatically handles pagination to fetch all 
 
 ```javascript
 const abilities = await getAbilities();
-console.log(`Found ${abilities.length} abilities`);
+console.log( `Found ${ abilities.length } abilities` );
 ```
 
 #### `getAbility(name: string): Promise<Ability | null>`
@@ -89,30 +89,30 @@ console.log(`Found ${abilities.length} abilities`);
 Returns a specific ability by name, or null if not found.
 
 ```javascript
-const ability = await getAbility('my-plugin/create-post');
-if (ability) {
-  console.log(`Found ability: ${ability.label}`);
+const ability = await getAbility( 'my-plugin/create-post' );
+if ( ability ) {
+  console.log( `Found ability: ${ ability.label }` );
 }
 ```
 
 #### `executeAbility(name: string, input?: Record<string, any>): Promise<any>`
 
-Executes an ability with optional input parameters. The HTTP method is automatically determined based on the ability's type:
+Executes an ability with optional input parameters. The HTTP method is automatically determined based on the ability's annotations:
 
-- `resource` type abilities use GET (read-only operations)
-- `tool` type abilities use POST (write operations)
+- `read_only` abilities use GET (read-only operations)
+- regular abilities use POST (write operations)
 
 ```javascript
-// Execute a resource ability (GET)
-const data = await executeAbility('my-plugin/get-data', {
+// Execute a read only ability (GET)
+const data = await executeAbility( 'my-plugin/get-data', {
   id: 123,
-});
+} );
 
-// Execute a tool ability (POST)
-const result = await executeAbility('my-plugin/create-item', {
+// Execute a regular ability (POST)
+const result = await executeAbility( 'my-plugin/create-item', {
   title: 'New Item',
   content: 'Item content',
-});
+} );
 ```
 
 ### Store Selectors

--- a/packages/client/src/__tests__/api.test.ts
+++ b/packages/client/src/__tests__/api.test.ts
@@ -259,12 +259,12 @@ describe( 'API functions', () => {
 			).rejects.toThrow( 'invalid input' );
 		} );
 
-		it( 'should execute a resource-type ability via GET', async () => {
+		it( 'should execute a read only ability via GET', async () => {
 			const mockAbility: Ability = {
-				name: 'test/resource',
-				label: 'Resource Ability',
-				description: 'Test resource ability',
-				meta: { type: 'resource' },
+				name: 'test/read-only',
+				label: 'Read only Ability',
+				description: 'Test read only ability.',
+				annotations: { read_only: true },
 				input_schema: {
 					type: 'object',
 					properties: {
@@ -280,27 +280,27 @@ describe( 'API functions', () => {
 				getAbility: mockGetAbility,
 			} );
 
-			const mockResponse = { data: 'resource data' };
+			const mockResponse = { data: 'read only data' };
 			( apiFetch as unknown as jest.Mock ).mockResolvedValue(
 				mockResponse
 			);
 
 			const input = { id: '123', format: 'json' };
-			const result = await executeAbility( 'test/resource', input );
+			const result = await executeAbility( 'test/read-only', input );
 
 			expect( apiFetch ).toHaveBeenCalledWith( {
-				path: '/wp/v2/abilities/test/resource/run?input%5Bid%5D=123&input%5Bformat%5D=json',
+				path: '/wp/v2/abilities/test/read-only/run?input%5Bid%5D=123&input%5Bformat%5D=json',
 				method: 'GET',
 			} );
 			expect( result ).toEqual( mockResponse );
 		} );
 
-		it( 'should execute a resource-type ability with empty input', async () => {
+		it( 'should execute a read only ability with empty input', async () => {
 			const mockAbility: Ability = {
-				name: 'test/resource',
-				label: 'Resource Ability',
-				description: 'Test resource ability',
-				meta: { type: 'resource' },
+				name: 'test/read-only',
+				label: 'Read only Ability',
+				description: 'Test read only ability.',
+				annotations: { read_only: true },
 				input_schema: { type: 'object' },
 				output_schema: { type: 'object' },
 			};
@@ -310,15 +310,15 @@ describe( 'API functions', () => {
 				getAbility: mockGetAbility,
 			} );
 
-			const mockResponse = { data: 'all resources' };
+			const mockResponse = { data: 'read only data' };
 			( apiFetch as unknown as jest.Mock ).mockResolvedValue(
 				mockResponse
 			);
 
-			const result = await executeAbility( 'test/resource', {} );
+			const result = await executeAbility( 'test/read-only', {} );
 
 			expect( apiFetch ).toHaveBeenCalledWith( {
-				path: '/wp/v2/abilities/test/resource/run?',
+				path: '/wp/v2/abilities/test/read-only/run?',
 				method: 'GET',
 			} );
 			expect( result ).toEqual( mockResponse );

--- a/packages/client/src/__tests__/api.test.ts
+++ b/packages/client/src/__tests__/api.test.ts
@@ -259,12 +259,12 @@ describe( 'API functions', () => {
 			).rejects.toThrow( 'invalid input' );
 		} );
 
-		it( 'should execute a read only ability via GET', async () => {
+		it( 'should execute a read-only ability via GET', async () => {
 			const mockAbility: Ability = {
 				name: 'test/read-only',
-				label: 'Read only Ability',
-				description: 'Test read only ability.',
-				annotations: { read_only: true },
+				label: 'Read-only Ability',
+				description: 'Test read-only ability.',
+				annotations: { readonly: true },
 				input_schema: {
 					type: 'object',
 					properties: {
@@ -280,7 +280,7 @@ describe( 'API functions', () => {
 				getAbility: mockGetAbility,
 			} );
 
-			const mockResponse = { data: 'read only data' };
+			const mockResponse = { data: 'read-only data' };
 			( apiFetch as unknown as jest.Mock ).mockResolvedValue(
 				mockResponse
 			);
@@ -295,12 +295,12 @@ describe( 'API functions', () => {
 			expect( result ).toEqual( mockResponse );
 		} );
 
-		it( 'should execute a read only ability with empty input', async () => {
+		it( 'should execute a read-only ability with empty input', async () => {
 			const mockAbility: Ability = {
 				name: 'test/read-only',
-				label: 'Read only Ability',
-				description: 'Test read only ability.',
-				annotations: { read_only: true },
+				label: 'Read-only Ability',
+				description: 'Test read-only ability.',
+				annotations: { readonly: true },
 				input_schema: { type: 'object' },
 				output_schema: { type: 'object' },
 			};
@@ -310,7 +310,7 @@ describe( 'API functions', () => {
 				getAbility: mockGetAbility,
 			} );
 
-			const mockResponse = { data: 'read only data' };
+			const mockResponse = { data: 'read-only data' };
 			( apiFetch as unknown as jest.Mock ).mockResolvedValue(
 				mockResponse
 			);

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -176,8 +176,7 @@ async function executeServerAbility(
 	ability: Ability,
 	input: AbilityInput
 ): Promise< AbilityOutput > {
-	const isResource = ability.meta?.type === 'resource';
-	const method = isResource ? 'GET' : 'POST';
+	const method = !! ability.annotations?.read_only ? 'GET' : 'POST';
 
 	let path = `/wp/v2/abilities/${ ability.name }/run`;
 	const options: {

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -176,7 +176,7 @@ async function executeServerAbility(
 	ability: Ability,
 	input: AbilityInput
 ): Promise< AbilityOutput > {
-	const method = !! ability.annotations?.read_only ? 'GET' : 'POST';
+	const method = !! ability.annotations?.readonly ? 'GET' : 'POST';
 
 	let path = `/wp/v2/abilities/${ ability.name }/run`;
 	const options: {

--- a/packages/client/src/store/__tests__/reducer.test.ts
+++ b/packages/client/src/store/__tests__/reducer.test.ts
@@ -118,46 +118,21 @@ describe( 'Store Reducer', () => {
 				).not.toHaveProperty( '_embedded' );
 			} );
 
-			it( 'should filter out location property', () => {
-				const abilities = [
-					{
-						name: 'test/ability',
-						label: 'Test Ability',
-						description: 'Test ability with location',
-						location: 'client',
-					},
-				];
-
-				const action = {
-					type: RECEIVE_ABILITIES,
-					abilities,
-				};
-
-				const state = reducer(
-					{ abilitiesByName: defaultState },
-					action
-				);
-
-				expect(
-					state.abilitiesByName[ 'test/ability' ]
-				).not.toHaveProperty( 'location' );
-			} );
-
 			it( 'should preserve all valid ability properties', () => {
 				const abilities = [
 					{
 						name: 'test/ability',
 						label: 'Test Ability',
-						description: 'Full test ability',
+						description: 'Full test ability.',
 						input_schema: { type: 'object' },
 						output_schema: { type: 'object' },
-						meta: { type: 'resource' as const },
+						annotations: { read_only: true },
+						meta: { category: 'test' },
 						callback: () => Promise.resolve( {} ),
 						permissionCallback: () => true,
 						// Extra properties that should be filtered out
 						_links: { self: { href: '/test' } },
 						_embedded: { test: 'value' },
-						location: 'client',
 						extra_field: 'should be removed',
 					},
 				];
@@ -176,17 +151,17 @@ describe( 'Store Reducer', () => {
 				// Should have valid properties
 				expect( ability.name ).toBe( 'test/ability' );
 				expect( ability.label ).toBe( 'Test Ability' );
-				expect( ability.description ).toBe( 'Full test ability' );
+				expect( ability.description ).toBe( 'Full test ability.' );
 				expect( ability.input_schema ).toEqual( { type: 'object' } );
 				expect( ability.output_schema ).toEqual( { type: 'object' } );
-				expect( ability.meta ).toEqual( { type: 'resource' } );
+				expect( ability.annotations ).toEqual( { read_only: true } );
+				expect( ability.meta ).toEqual( { category: 'test' } );
 				expect( ability.callback ).toBeDefined();
 				expect( ability.permissionCallback ).toBeDefined();
 
 				// Should NOT have invalid properties
 				expect( ability ).not.toHaveProperty( '_links' );
 				expect( ability ).not.toHaveProperty( '_embedded' );
-				expect( ability ).not.toHaveProperty( 'location' );
 				expect( ability ).not.toHaveProperty( 'extra_field' );
 			} );
 		} );
@@ -225,7 +200,6 @@ describe( 'Store Reducer', () => {
 					description: 'Test ability',
 					callback: () => Promise.resolve( {} ),
 					// Extra properties that should be filtered out
-					location: 'client',
 					_links: { self: { href: '/test' } },
 					extra_field: 'should be removed',
 				};
@@ -249,7 +223,6 @@ describe( 'Store Reducer', () => {
 				expect( registeredAbility.callback ).toBeDefined();
 
 				// Should NOT have invalid properties
-				expect( registeredAbility ).not.toHaveProperty( 'location' );
 				expect( registeredAbility ).not.toHaveProperty( '_links' );
 				expect( registeredAbility ).not.toHaveProperty( 'extra_field' );
 			} );

--- a/packages/client/src/store/__tests__/reducer.test.ts
+++ b/packages/client/src/store/__tests__/reducer.test.ts
@@ -126,7 +126,7 @@ describe( 'Store Reducer', () => {
 						description: 'Full test ability.',
 						input_schema: { type: 'object' },
 						output_schema: { type: 'object' },
-						annotations: { read_only: true },
+						annotations: { readonly: true },
 						meta: { category: 'test' },
 						callback: () => Promise.resolve( {} ),
 						permissionCallback: () => true,
@@ -154,7 +154,7 @@ describe( 'Store Reducer', () => {
 				expect( ability.description ).toBe( 'Full test ability.' );
 				expect( ability.input_schema ).toEqual( { type: 'object' } );
 				expect( ability.output_schema ).toEqual( { type: 'object' } );
-				expect( ability.annotations ).toEqual( { read_only: true } );
+				expect( ability.annotations ).toEqual( { readonly: true } );
 				expect( ability.meta ).toEqual( { category: 'test' } );
 				expect( ability.callback ).toBeDefined();
 				expect( ability.permissionCallback ).toBeDefined();

--- a/packages/client/src/store/reducer.ts
+++ b/packages/client/src/store/reducer.ts
@@ -23,6 +23,7 @@ const ABILITY_KEYS = [
 	'description',
 	'input_schema',
 	'output_schema',
+	'annotations',
 	'meta',
 	'callback',
 	'permissionCallback',

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -69,14 +69,21 @@ export interface Ability {
 	permissionCallback?: PermissionCallback;
 
 	/**
+	 * Annotation for the ability.
+	 * @see WP_Ability::get_annotations()
+	 */
+	annotations?: {
+		instructions?: string;
+		read_only?: boolean;
+		destructive?: boolean;
+		idempotent?: boolean;
+	};
+
+	/**
 	 * Metadata about the ability.
 	 * @see WP_Ability::get_meta()
 	 */
 	meta?: {
-		/**
-		 * The type of ability - 'resource' uses GET, 'tool' uses POST.
-		 */
-		type?: 'resource' | 'tool';
 		[ key: string ]: any;
 	};
 }

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -74,7 +74,7 @@ export interface Ability {
 	 */
 	annotations?: {
 		instructions?: string;
-		read_only?: boolean;
+		readonly?: boolean;
 		destructive?: boolean;
 		idempotent?: boolean;
 	};

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -69,7 +69,7 @@ export interface Ability {
 	permissionCallback?: PermissionCallback;
 
 	/**
-	 * Annotation for the ability.
+	 * Annotations for the ability.
 	 * @see WP_Ability::get_annotations()
 	 */
 	annotations?: {

--- a/tests/unit/abilities-api/wpAbilitiesRegistry.php
+++ b/tests/unit/abilities-api/wpAbilitiesRegistry.php
@@ -266,6 +266,22 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 		$this->assertNull( $result );
 	}
 
+
+	/**
+	 * Should reject ability registration with invalid `annotations` type.
+	 *
+	 * @covers WP_Abilities_Registry::register
+	 * @covers WP_Ability::prepare_properties
+	 *
+	 * @expectedIncorrectUsage WP_Abilities_Registry::register
+	 */
+	public function test_register_invalid_annotations_type() {
+		self::$test_ability_args['annotations'] = false;
+
+		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_args );
+		$this->assertNull( $result );
+	}
+
 	/**
 	 * Should reject ability registration with invalid meta type.
 	 *

--- a/tests/unit/abilities-api/wpAbilitiesRegistry.php
+++ b/tests/unit/abilities-api/wpAbilitiesRegistry.php
@@ -59,9 +59,6 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 			'permission_callback' => static function (): bool {
 				return true;
 			},
-			'annotations'         => array(
-				'read_only' => true,
-			),
 			'meta'                => array(
 				'category' => 'math',
 			),

--- a/tests/unit/abilities-api/wpAbilitiesRegistry.php
+++ b/tests/unit/abilities-api/wpAbilitiesRegistry.php
@@ -59,6 +59,9 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 			'permission_callback' => static function (): bool {
 				return true;
 			},
+			'annotations'         => array(
+				'read_only' => true,
+			),
 			'meta'                => array(
 				'category' => 'math',
 			),

--- a/tests/unit/abilities-api/wpAbility.php
+++ b/tests/unit/abilities-api/wpAbility.php
@@ -26,11 +26,15 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 				'description' => 'The result of performing a math operation.',
 				'required'    => true,
 			),
+			'execute_callback'   => static function (): int {
+				return 0;
+			},
 			'permission_callback' => static function (): bool {
 				return true;
 			},
 			'annotations'         => array(
-				'read_only' => true,
+				'read_only'    => true,
+				'destructive'  => false,
 			),
 			'meta'                => array(
 				'category' => 'math',
@@ -349,9 +353,6 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 				'permission_callback' => static function (): bool {
 					return false;
 				},
-				'execute_callback'    => static function (): int {
-					return 42;
-				},
 			)
 		);
 
@@ -456,5 +457,65 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 		$this->assertTrue( $before_action_fired, 'before_execute_ability action should be fired even if output validation fails' );
 		$this->assertFalse( $after_action_fired, 'after_execute_ability action should not be fired when output validation fails' );
 		$this->assertInstanceOf( WP_Error::class, $result, 'Should return WP_Error for output validation failure' );
+	}
+
+	/**
+	 * Tests getting all annotations when selective overrides are applied.
+	 */
+	public function test_get_all_annotations() {
+		$ability = new WP_Ability( self::$test_ability_name, self::$test_ability_properties );
+
+		$this->assertEquals(
+			array_merge(
+				self::$test_ability_properties['annotations'],
+				array(
+					'instructions' => '',
+					'idempotent'   => false,
+				),
+			),
+			$ability->get_annotations()
+		);
+	}
+
+	/**
+	 * Tests getting default annotations when not provided.
+	 */
+	public function test_get_default_annotations() {
+		$args = self::$test_ability_properties;
+		unset( $args['annotations'] );
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+
+		$this->assertSame(
+			array(
+				'instructions' => '',
+				'read_only'    => false,
+				'destructive'  => true,
+				'idempotent'   => false,
+			),
+			$ability->get_annotations()
+		);
+	}
+
+	/**
+	 * Tests getting all annotations when values overridden.
+	 */
+	public function test_get_all_annotations_overridden() {
+		$annotations = array(
+			'instructions' => 'Enjoy responsibly.',
+			'read_only'    => true,
+			'destructive'  => false,
+			'idempotent'   => false,
+		);
+		$args        = array_merge(
+			self::$test_ability_properties,
+			array(
+				'annotations' => $annotations,
+			)
+		);
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+
+		$this->assertSame( $annotations, $ability->get_annotations() );
 	}
 }

--- a/tests/unit/abilities-api/wpAbility.php
+++ b/tests/unit/abilities-api/wpAbility.php
@@ -33,7 +33,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 				return true;
 			},
 			'annotations'         => array(
-				'read_only'    => true,
+				'readonly'    => true,
 				'destructive'  => false,
 			),
 			'meta'                => array(
@@ -489,7 +489,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'instructions' => '',
-				'read_only'    => false,
+				'readonly'    => false,
 				'destructive'  => true,
 				'idempotent'   => false,
 			),
@@ -503,7 +503,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	public function test_get_all_annotations_overridden() {
 		$annotations = array(
 			'instructions' => 'Enjoy responsibly.',
-			'read_only'    => true,
+			'readonly'    => true,
 			'destructive'  => false,
 			'idempotent'   => false,
 		);

--- a/tests/unit/abilities-api/wpAbility.php
+++ b/tests/unit/abilities-api/wpAbility.php
@@ -34,7 +34,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 			},
 			'annotations'         => array(
 				'readonly'    => true,
-				'destructive'  => false,
+				'destructive' => false,
 			),
 			'meta'                => array(
 				'category' => 'math',
@@ -489,7 +489,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'instructions' => '',
-				'readonly'    => false,
+				'readonly'     => false,
 				'destructive'  => true,
 				'idempotent'   => false,
 			),
@@ -503,7 +503,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	public function test_get_all_annotations_overridden() {
 		$annotations = array(
 			'instructions' => 'Enjoy responsibly.',
-			'readonly'    => true,
+			'readonly'     => true,
 			'destructive'  => false,
 			'idempotent'   => false,
 		);

--- a/tests/unit/abilities-api/wpAbility.php
+++ b/tests/unit/abilities-api/wpAbility.php
@@ -43,6 +43,82 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests getting all annotations when selective overrides are applied.
+	 */
+	public function test_get_all_annotations() {
+		$ability = new WP_Ability( self::$test_ability_name, self::$test_ability_properties );
+
+		$this->assertEquals(
+			array_merge(
+				self::$test_ability_properties['annotations'],
+				array(
+					'instructions' => '',
+					'idempotent'   => false,
+				),
+			),
+			$ability->get_annotations()
+		);
+	}
+
+	/**
+	 * Tests getting default annotations when not provided.
+	 */
+	public function test_get_default_annotations() {
+		$args = self::$test_ability_properties;
+		unset( $args['annotations'] );
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+
+		$this->assertSame(
+			array(
+				'instructions' => '',
+				'readonly'     => false,
+				'destructive'  => true,
+				'idempotent'   => false,
+			),
+			$ability->get_annotations()
+		);
+	}
+
+	/**
+	 * Tests getting all annotations when values overridden.
+	 */
+	public function test_get_all_annotations_overridden() {
+		$annotations = array(
+			'instructions' => 'Enjoy responsibly.',
+			'readonly'     => true,
+			'destructive'  => false,
+			'idempotent'   => false,
+		);
+		$args        = array_merge(
+			self::$test_ability_properties,
+			array(
+				'annotations' => $annotations,
+			)
+		);
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+
+		$this->assertSame( $annotations, $ability->get_annotations() );
+	}
+	/**
+	 * Tests that invalid annotations throw an exception.
+	 */
+	public function test_annotations_throws_exception() {
+		$args = array_merge(
+			self::$test_ability_properties,
+			array(
+				'annotations' => 5,
+			)
+		);
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'The ability properties should provide a valid `annotations` array.' );
+
+		new WP_Ability( self::$test_ability_name, $args );
+	}
+
+	/**
 	 * Data provider for testing the execution of the ability.
 	 */
 	public function data_execute_input() {
@@ -457,65 +533,5 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 		$this->assertTrue( $before_action_fired, 'before_execute_ability action should be fired even if output validation fails' );
 		$this->assertFalse( $after_action_fired, 'after_execute_ability action should not be fired when output validation fails' );
 		$this->assertInstanceOf( WP_Error::class, $result, 'Should return WP_Error for output validation failure' );
-	}
-
-	/**
-	 * Tests getting all annotations when selective overrides are applied.
-	 */
-	public function test_get_all_annotations() {
-		$ability = new WP_Ability( self::$test_ability_name, self::$test_ability_properties );
-
-		$this->assertEquals(
-			array_merge(
-				self::$test_ability_properties['annotations'],
-				array(
-					'instructions' => '',
-					'idempotent'   => false,
-				),
-			),
-			$ability->get_annotations()
-		);
-	}
-
-	/**
-	 * Tests getting default annotations when not provided.
-	 */
-	public function test_get_default_annotations() {
-		$args = self::$test_ability_properties;
-		unset( $args['annotations'] );
-
-		$ability = new WP_Ability( self::$test_ability_name, $args );
-
-		$this->assertSame(
-			array(
-				'instructions' => '',
-				'readonly'     => false,
-				'destructive'  => true,
-				'idempotent'   => false,
-			),
-			$ability->get_annotations()
-		);
-	}
-
-	/**
-	 * Tests getting all annotations when values overridden.
-	 */
-	public function test_get_all_annotations_overridden() {
-		$annotations = array(
-			'instructions' => 'Enjoy responsibly.',
-			'readonly'     => true,
-			'destructive'  => false,
-			'idempotent'   => false,
-		);
-		$args        = array_merge(
-			self::$test_ability_properties,
-			array(
-				'annotations' => $annotations,
-			)
-		);
-
-		$ability = new WP_Ability( self::$test_ability_name, $args );
-
-		$this->assertSame( $annotations, $ability->get_annotations() );
 	}
 }

--- a/tests/unit/abilities-api/wpAbility.php
+++ b/tests/unit/abilities-api/wpAbility.php
@@ -29,6 +29,9 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 			'permission_callback' => static function (): bool {
 				return true;
 			},
+			'annotations'         => array(
+				'read_only' => true,
+			),
 			'meta'                => array(
 				'category' => 'math',
 			),

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -60,6 +60,9 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 			'permission_callback' => static function (): bool {
 				return true;
 			},
+			'annotations'         => array(
+				'read_only' => true,
+			),
 			'meta'                => array(
 				'category' => 'math',
 			),
@@ -132,6 +135,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 		$this->assertSame( self::$test_ability_args['description'], $result->get_description() );
 		$this->assertSame( self::$test_ability_args['input_schema'], $result->get_input_schema() );
 		$this->assertSame( self::$test_ability_args['output_schema'], $result->get_output_schema() );
+		$this->assertSame( self::$test_ability_args['annotations'], $result->get_annotations() );
 		$this->assertSame( self::$test_ability_args['meta'], $result->get_meta() );
 		$this->assertTrue(
 			$result->check_permissions(

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -61,7 +61,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 				return true;
 			},
 			'annotations'         => array(
-				'readonly'   => true,
+				'readonly'    => true,
 				'destructive' => false,
 			),
 			'meta'                => array(

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -61,7 +61,8 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 				return true;
 			},
 			'annotations'         => array(
-				'read_only' => true,
+				'read_only'   => true,
+				'destructive' => false,
 			),
 			'meta'                => array(
 				'category' => 'math',
@@ -135,7 +136,16 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 		$this->assertSame( self::$test_ability_args['description'], $result->get_description() );
 		$this->assertSame( self::$test_ability_args['input_schema'], $result->get_input_schema() );
 		$this->assertSame( self::$test_ability_args['output_schema'], $result->get_output_schema() );
-		$this->assertSame( self::$test_ability_args['annotations'], $result->get_annotations() );
+		$this->assertEquals(
+			array_merge(
+				array(
+					'instructions' => '',
+					'idempotent'   => false,
+				),
+				self::$test_ability_args['annotations'],
+			),
+			$result->get_annotations()
+		);
 		$this->assertSame( self::$test_ability_args['meta'], $result->get_meta() );
 		$this->assertTrue(
 			$result->check_permissions(

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -61,7 +61,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 				return true;
 			},
 			'annotations'         => array(
-				'read_only'   => true,
+				'readonly'   => true,
 				'destructive' => false,
 			),
 			'meta'                => array(

--- a/tests/unit/rest-api/wpRestAbilitiesListController.php
+++ b/tests/unit/rest-api/wpRestAbilitiesListController.php
@@ -122,7 +122,6 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 					return current_user_can( 'read' );
 				},
 				'meta'                => array(
-					'type'     => 'tool',
 					'category' => 'math',
 				),
 			)
@@ -165,7 +164,6 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 					return current_user_can( 'read' );
 				},
 				'meta'                => array(
-					'type'     => 'resource',
 					'category' => 'system',
 				),
 			)
@@ -223,7 +221,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'input_schema', $data );
 		$this->assertArrayHasKey( 'output_schema', $data );
 		$this->assertArrayHasKey( 'meta', $data );
-		$this->assertEquals( 'tool', $data['meta']['type'] );
+		$this->assertEquals( 'math', $data['meta']['category'] );
 	}
 
 	/**

--- a/tests/unit/rest-api/wpRestAbilitiesListController.php
+++ b/tests/unit/rest-api/wpRestAbilitiesListController.php
@@ -127,7 +127,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 			)
 		);
 
-		// Register a read only ability.
+		// Register a read-only ability.
 		wp_register_ability(
 			'test/system-info',
 			array(
@@ -164,7 +164,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 					return current_user_can( 'read' );
 				},
 				'annotations'         => array(
-					'read_only' => true,
+					'readonly' => true,
 				),
 				'meta'                => array(
 					'category' => 'system',

--- a/tests/unit/rest-api/wpRestAbilitiesListController.php
+++ b/tests/unit/rest-api/wpRestAbilitiesListController.php
@@ -84,7 +84,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 	 * Register test abilities for testing.
 	 */
 	private function register_test_abilities(): void {
-		// Register a tool ability
+		// Register a regular ability.
 		wp_register_ability(
 			'test/calculator',
 			array(
@@ -127,7 +127,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 			)
 		);
 
-		// Register a resource ability
+		// Register a read only ability.
 		wp_register_ability(
 			'test/system-info',
 			array(
@@ -163,6 +163,9 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 				'permission_callback' => static function () {
 					return current_user_can( 'read' );
 				},
+				'annotations'         => array(
+					'read_only' => true,
+				),
 				'meta'                => array(
 					'category' => 'system',
 				),

--- a/tests/unit/rest-api/wpRestAbilitiesRunController.php
+++ b/tests/unit/rest-api/wpRestAbilitiesRunController.php
@@ -91,7 +91,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 	 * Register test abilities for testing.
 	 */
 	private function register_test_abilities(): void {
-		// Tool ability (POST only)
+		// Regular ability (POST only).
 		wp_register_ability(
 			'test/calculator',
 			array(
@@ -124,7 +124,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 			)
 		);
 
-		// Resource ability (GET only)
+		// Read only ability (GET method).
 		wp_register_ability(
 			'test/user-info',
 			array(
@@ -235,7 +235,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 			)
 		);
 
-		// Resource ability for query params testing
+		// Read only ability for query params testing.
 		wp_register_ability(
 			'test/query-params',
 			array(
@@ -260,9 +260,9 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test executing a tool ability with POST.
+	 * Test executing a regular ability with POST.
 	 */
-	public function test_execute_tool_ability_post(): void {
+	public function test_execute_regular_ability_post(): void {
 		$request = new WP_REST_Request( 'POST', '/wp/v2/abilities/test/calculator/run' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body(
@@ -303,9 +303,9 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test HTTP method validation for tool abilities.
+	 * Test HTTP method validation for regular abilities.
 	 */
-	public function test_tool_ability_requires_post(): void {
+	public function test_regular_ability_requires_post(): void {
 		wp_register_ability(
 			'test/open-tool',
 			array(
@@ -328,10 +328,10 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test HTTP method validation for resource abilities.
+	 * Test HTTP method validation for read only abilities.
 	 */
-	public function test_resource_ability_requires_get(): void {
-		// Try POST on a resource ability (should fail)
+	public function test_read_only_ability_requires_get(): void {
+		// Try POST on a read only ability (should fail).
 		$request = new WP_REST_Request( 'POST', '/wp/v2/abilities/test/user-info/run' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body( wp_json_encode( array( 'user_id' => 1 ) ) );
@@ -653,30 +653,29 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test ability type not set defaults to tool.
+	 * Test ability without annotations defaults to POST method.
 	 */
-	public function test_ability_without_type_defaults_to_tool(): void {
-		// Register ability without type in meta.
+	public function test_ability_without_annotations_defaults_to_post_method(): void {
+		// Register ability without annotations.
 		wp_register_ability(
-			'test/no-type',
+			'test/no-annotations',
 			array(
-				'label'               => 'No Type',
-				'description'         => 'Ability without type',
+				'label'               => 'No Annotations',
+				'description'         => 'Ability without annotations.',
 				'execute_callback'    => static function () {
 					return array( 'executed' => true );
 				},
 				'permission_callback' => '__return_true',
-				'meta'                => array(), // No type specified
 			)
 		);
 
-		// Should require POST (default tool behavior)
-		$get_request  = new WP_REST_Request( 'GET', '/wp/v2/abilities/test/no-type/run' );
+		// Should require POST (default behavior).
+		$get_request  = new WP_REST_Request( 'GET', '/wp/v2/abilities/test/no-annotations/run' );
 		$get_response = $this->server->dispatch( $get_request );
 		$this->assertEquals( 405, $get_response->get_status() );
 
-		// Should work with POST
-		$post_request = new WP_REST_Request( 'POST', '/wp/v2/abilities/test/no-type/run' );
+		// Should work with POST.
+		$post_request = new WP_REST_Request( 'POST', '/wp/v2/abilities/test/no-annotations/run' );
 		$post_request->set_header( 'Content-Type', 'application/json' );
 
 		$post_response = $this->server->dispatch( $post_request );
@@ -684,15 +683,15 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test edge case with empty input for both GET and POST.
+	 * Test edge case with empty input for both GET and POST methods.
 	 */
 	public function test_empty_input_handling(): void {
 		// Registers abilities for empty input testing.
 		wp_register_ability(
-			'test/resource-empty',
+			'test/read-only-empty',
 			array(
-				'label'               => 'Resource Empty',
-				'description'         => 'Resource with empty input',
+				'label'               => 'Read Only Empty',
+				'description'         => 'Read only with empty input.',
 				'execute_callback'    => static function () {
 					return array( 'input_was_empty' => 0 === func_num_args() );
 				},
@@ -704,10 +703,10 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		);
 
 		wp_register_ability(
-			'test/tool-empty',
+			'test/regular-empty',
 			array(
-				'label'               => 'Tool Empty',
-				'description'         => 'Tool with empty input',
+				'label'               => 'Regular Empty',
+				'description'         => 'Regular with empty input.',
 				'execute_callback'    => static function () {
 					return array( 'input_was_empty' => 0 === func_num_args() );
 				},
@@ -716,13 +715,13 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		);
 
 		// Tests GET with no input parameter.
-		$get_request  = new WP_REST_Request( 'GET', '/wp/v2/abilities/test/resource-empty/run' );
+		$get_request  = new WP_REST_Request( 'GET', '/wp/v2/abilities/test/read-only-empty/run' );
 		$get_response = $this->server->dispatch( $get_request );
 		$this->assertEquals( 200, $get_response->get_status() );
 		$this->assertTrue( $get_response->get_data()['input_was_empty'] );
 
 		// Tests POST with no body.
-		$post_request = new WP_REST_Request( 'POST', '/wp/v2/abilities/test/tool-empty/run' );
+		$post_request = new WP_REST_Request( 'POST', '/wp/v2/abilities/test/regular-empty/run' );
 		$post_request->set_header( 'Content-Type', 'application/json' );
 		$post_request->set_body( '{}' ); // Empty JSON object
 
@@ -892,7 +891,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		$request  = new WP_REST_Request( $method, '/wp/v2/abilities/test/method-test/run' );
 		$response = $this->server->dispatch( $request );
 
-		// Tool abilities should only accept POST, so these should return 405.
+		// Regular abilities should only accept POST, so these should return 405.
 		$this->assertSame( 405, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertSame( 'rest_ability_invalid_method', $data['code'] );

--- a/tests/unit/rest-api/wpRestAbilitiesRunController.php
+++ b/tests/unit/rest-api/wpRestAbilitiesRunController.php
@@ -124,7 +124,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 			)
 		);
 
-		// Read only ability (GET method).
+		// Read-only ability (GET method).
 		wp_register_ability(
 			'test/user-info',
 			array(
@@ -161,7 +161,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return is_user_logged_in();
 				},
 				'annotations'         => array(
-					'read_only' => true,
+					'readonly' => true,
 				),
 			)
 		);
@@ -235,7 +235,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 			)
 		);
 
-		// Read only ability for query params testing.
+		// Read-only ability for query params testing.
 		wp_register_ability(
 			'test/query-params',
 			array(
@@ -253,7 +253,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 				},
 				'permission_callback' => '__return_true',
 				'annotations'         => array(
-					'read_only' => true,
+					'readonly' => true,
 				),
 			)
 		);
@@ -283,9 +283,9 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test executing a read only ability with GET.
+	 * Test executing a read-only ability with GET.
 	 */
-	public function test_execute_read_only_ability_get(): void {
+	public function test_execute_readonly_ability_get(): void {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/abilities/test/user-info/run' );
 		$request->set_query_params(
 			array(
@@ -328,10 +328,10 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test HTTP method validation for read only abilities.
+	 * Test HTTP method validation for read-only abilities.
 	 */
-	public function test_read_only_ability_requires_get(): void {
-		// Try POST on a read only ability (should fail).
+	public function test_readonly_ability_requires_get(): void {
+		// Try POST on a read-only ability (should fail).
 		$request = new WP_REST_Request( 'POST', '/wp/v2/abilities/test/user-info/run' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body( wp_json_encode( array( 'user_id' => 1 ) ) );
@@ -341,7 +341,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		$this->assertSame( 405, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertSame( 'rest_ability_invalid_method', $data['code'] );
-		$this->assertSame( 'Read only abilities require GET method.', $data['message'] );
+		$this->assertSame( 'Read-only abilities require GET method.', $data['message'] );
 	}
 
 
@@ -690,14 +690,14 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		wp_register_ability(
 			'test/read-only-empty',
 			array(
-				'label'               => 'Read Only Empty',
-				'description'         => 'Read only with empty input.',
+				'label'               => 'Read-only Empty',
+				'description'         => 'Read-only with empty input.',
 				'execute_callback'    => static function () {
 					return array( 'input_was_empty' => 0 === func_num_args() );
 				},
 				'permission_callback' => '__return_true',
 				'annotations'         => array(
-					'read_only' => true,
+					'readonly' => true,
 				),
 			)
 		);

--- a/tests/unit/rest-api/wpRestAbilitiesRunController.php
+++ b/tests/unit/rest-api/wpRestAbilitiesRunController.php
@@ -121,9 +121,6 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 				'permission_callback' => static function () {
 					return current_user_can( 'edit_posts' );
 				},
-				'meta'                => array(
-					'type' => 'tool',
-				),
 			)
 		);
 
@@ -163,8 +160,8 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 				'permission_callback' => static function () {
 					return is_user_logged_in();
 				},
-				'meta'                => array(
-					'type' => 'resource',
+				'annotations'         => array(
+					'read_only' => true,
 				),
 			)
 		);
@@ -193,9 +190,6 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					// Only allow if secret matches
 					return isset( $input['secret'] ) && 'valid_secret' === $input['secret'];
 				},
-				'meta'                => array(
-					'type' => 'tool',
-				),
 			)
 		);
 
@@ -209,9 +203,6 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return null;
 				},
 				'permission_callback' => '__return_true',
-				'meta'                => array(
-					'type' => 'tool',
-				),
 			)
 		);
 
@@ -225,9 +216,6 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return new \WP_Error( 'test_error', 'This is a test error' );
 				},
 				'permission_callback' => '__return_true',
-				'meta'                => array(
-					'type' => 'tool',
-				),
 			)
 		);
 
@@ -244,9 +232,6 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return 'not a number'; // Invalid - schema expects number
 				},
 				'permission_callback' => '__return_true',
-				'meta'                => array(
-					'type' => 'tool',
-				),
 			)
 		);
 
@@ -267,8 +252,8 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return $input;
 				},
 				'permission_callback' => '__return_true',
-				'meta'                => array(
-					'type' => 'resource',
+				'annotations'         => array(
+					'read_only' => true,
 				),
 			)
 		);
@@ -298,9 +283,9 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test executing a resource ability with GET.
+	 * Test executing a read only ability with GET.
 	 */
-	public function test_execute_resource_ability_get(): void {
+	public function test_execute_read_only_ability_get(): void {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/abilities/test/user-info/run' );
 		$request->set_query_params(
 			array(
@@ -330,9 +315,6 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return 'success';
 				},
 				'permission_callback' => '__return_true',
-				'meta'                => array(
-					'type' => 'tool',
-				),
 			)
 		);
 
@@ -342,7 +324,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		$this->assertSame( 405, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertSame( 'rest_ability_invalid_method', $data['code'] );
-		$this->assertSame( 'Tool abilities require POST method.', $data['message'] );
+		$this->assertSame( 'Abilities that perform updates require POST method.', $data['message'] );
 	}
 
 	/**
@@ -359,7 +341,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		$this->assertSame( 405, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertSame( 'rest_ability_invalid_method', $data['code'] );
-		$this->assertSame( 'Resource abilities require GET method.', $data['message'] );
+		$this->assertSame( 'Read only abilities require GET method.', $data['message'] );
 	}
 
 
@@ -609,7 +591,6 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return array( 'wrong_field' => 'value' );
 				},
 				'permission_callback' => '__return_true',
-				'meta'                => array( 'type' => 'tool' ),
 			)
 		);
 
@@ -651,7 +632,6 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return array( 'status' => 'success' );
 				},
 				'permission_callback' => '__return_true',
-				'meta'                => array( 'type' => 'tool' ),
 			)
 		);
 
@@ -717,7 +697,9 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return array( 'input_was_empty' => 0 === func_num_args() );
 				},
 				'permission_callback' => '__return_true',
-				'meta'                => array( 'type' => 'resource' ),
+				'annotations'         => array(
+					'read_only' => true,
+				),
 			)
 		);
 
@@ -730,7 +712,6 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return array( 'input_was_empty' => 0 === func_num_args() );
 				},
 				'permission_callback' => '__return_true',
-				'meta'                => array( 'type' => 'tool' ),
 			)
 		);
 
@@ -803,7 +784,6 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return array( 'echo' => $input );
 				},
 				'permission_callback' => '__return_true',
-				'meta'                => array( 'type' => 'tool' ),
 			)
 		);
 
@@ -847,7 +827,6 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return array( 'echo' => $input );
 				},
 				'permission_callback' => '__return_true',
-				'meta'                => array( 'type' => 'tool' ),
 			)
 		);
 
@@ -907,7 +886,6 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return array( 'success' => true );
 				},
 				'permission_callback' => '__return_true', // No permission requirements
-				'meta'                => array( 'type' => 'tool' ),
 			)
 		);
 
@@ -918,7 +896,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		$this->assertSame( 405, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertSame( 'rest_ability_invalid_method', $data['code'] );
-		$this->assertSame( 'Tool abilities require POST method.', $data['message'] );
+		$this->assertSame( 'Abilities that perform updates require POST method.', $data['message'] );
 	}
 
 	/**


### PR DESCRIPTION
Closes #62.

## What

> Oftentimes we want to give the AI different instructions for when it's about to perform a destructive action, such as framing what's about to happen and requesting confirmation to the user. It would be helpful, therefore, to have a property of an Ability that marks it as a destructive ability.

I took some inspiration from [ToolAnnotation in MCP](https://modelcontextprotocol.io/specification/2025-06-18/schema#toolannotations). For starters, we will need `read_only` to replace the current logic that uses `meta.tool` to distinguish between HTTP method usage (i.e., `GET` and `POST`) in requests.

## Why

The best explanation of the root problem that is being addressed comes from @galatanovidiu in https://github.com/WordPress/mcp-adapter/pull/48#discussion_r2399844161

> It would be great to leverage the same metadata in MCP, but we need to address a fundamental terminology mismatch first.
>
> The core issue: WordPress Abilities API and MCP use "tools" and "resources" to mean completely different things:
>
> **WordPress Abilities API:**
>
> Tools = callable functions that modify data
> Resources = callable functions that read data
>
> **MCP:**
>
> Tools = callable functions that the AI invokes automatically when needed
> Resources = static context that users manually attach to conversations
>
> So WordPress's "tool vs resource" distinction doesn't map to MCP's "tool vs resource"
>
> **Concrete example:** A site-info ability could be implemented as:
>
> MCP tool: AI calls it when it needs current site data during conversation
> MCP resource: User pre-attaches site info as reference context
>
> The choice depends on the usage pattern (AI-driven vs. user-driven), not the type of action.

Here, we remove all references to `tool` and `resource` nomenclature. Instead, we perform detection of the `GET` vs `POST` method in the REST API calls based on annotations that describe what the ability does: read only vs updates data.

## Fute considerations

With more properties, we could also start using `DELETE` HTTP method as I explore `idempotent` and `destructive` annotations.  I'm also interested in including freeform `instructions` so devs could consist of usage examples for both the user and for consideration to pass to LLMs.

## Testing

Run test:

```bash
npm run test:php
npm run test:client
```

