### PR TITLE
Add new `show_in_rest` arg to control REST API exposure

### DIFF
--- a/docs/1.intro.md
+++ b/docs/1.intro.md
@@ -12,7 +12,7 @@ It acts as a central registry, making it easier for different parts of WordPress
 - **Registry:** A central, singleton object (`WP_Abilities_Registry`) that holds all registered abilities. It provides methods for registering, unregistering, finding, and querying abilities.
 - **Callback:** The PHP function or method executed when an ability is called via `WP_Ability::execute()`.
 - **Schema:** JSON Schema definitions for an ability's expected input (`input_schema`) and its returned output (`output_schema`). This allows for validation and helps agents understand how to use the ability.
-- **Permission Callback:** An optional function that determines if the current user can execute a specific ability. 
+- **Permission Callback:** An optional function that determines if the current user can execute a specific ability.
 - **Namespace:** The first part of an ability name (before the slash), typically matching the plugin or component name that registers the ability.
 
 ## Goals and Benefits
@@ -76,7 +76,8 @@ function my_plugin_register_ability(){
 		'execute_callback' => 'my_plugin_get_siteinfo',
 		'permission_callback' => function( $input ) {
 			return current_user_can( 'manage_options' );
-		}
+		},
+    'show_in_rest' => true,
 	));
 }
 ```

--- a/docs/2.getting-started.md
+++ b/docs/2.getting-started.md
@@ -124,6 +124,7 @@ function my_plugin_register_abilities() {
         'meta'                => array(
             'category' => 'site-info',
         ),
+        'show_in_rest'        => true, // Optional: expose via REST API
     ) );
 }
 

--- a/docs/3.registering-abilities.md
+++ b/docs/3.registering-abilities.md
@@ -27,6 +27,9 @@ The `$args` array accepts the following keys:
   - The callback receives one optional argument: it can have any type as defined in the input schema (e.g., `array`, `object`, `string`, etc.).
   - The callback should return a boolean (`true` if the user has permission, `false` otherwise), or a `WP_Error` object on failure.
   - If the input does not validate against the input schema, the permission callback will not be called, and a `WP_Error` will be returned instead.
+- `show_in_rest` (`boolean`, **Optional**): Whether to expose this ability via the REST API. Default: `false`.
+  - When `true`, the ability will be listed in REST API responses and can be executed via REST endpoints.
+  - When `false`, the ability will be hidden from REST API listings and cannot be executed via REST endpoints, but remains available for internal PHP usage.
 - `meta` (`array`, **Optional**): An associative array for storing arbitrary additional metadata about the ability.
 
 ## Ability ID Convention

--- a/docs/5.rest-api.md
+++ b/docs/5.rest-api.md
@@ -6,6 +6,15 @@ The WordPress Abilities API provides REST endpoints that allow external systems 
 
 Access to all Abilities REST API endpoints requires an authenticated user (see the [Authentication](#authentication) section). Access to execute individual Abilities is restricted based on the `permission_callback()` of the Ability.
 
+## Controlling REST API Exposure
+
+By default, registered abilities are **not** exposed via the REST API. You can control whether an individual ability appears in the REST API by using the `show_in_rest` argument when registering the ability:
+
+- `show_in_rest => true`: The ability is listed in REST API responses and can be executed via REST endpoints.
+- `show_in_rest => false` (default): The ability is hidden from REST API listings and cannot be executed via REST endpoints. The ability remains available for internal PHP usage via `wp_execute_ability()`.
+
+Abilities with `show_in_rest => false` will return a `rest_ability_not_found` error if accessed via REST endpoints.
+
 ## Schema
 
 The Abilities API endpoints are available under the `/wp/v2/abilities` namespace.

--- a/includes/abilities-api.php
+++ b/includes/abilities-api.php
@@ -25,7 +25,7 @@ declare( strict_types = 1 );
  *                                  alphanumeric characters, dashes and the forward slash.
  * @param array<string,mixed> $args An associative array of arguments for the ability. This should include
  *                                  `label`, `description`, `input_schema`, `output_schema`, `execute_callback`,
- *                                  `permission_callback`, `annotations`, `meta`, and `ability_class`.
+ *                                  `permission_callback`, `annotations`, `meta`, `show_in_rest`, and `ability_class`.
  * @return ?\WP_Ability An instance of registered ability on success, null on failure.
  *
  * @phpstan-param array{
@@ -37,6 +37,7 @@ declare( strict_types = 1 );
  *   output_schema?: array<string,mixed>,
  *   annotations?: array<string,mixed>,
  *   meta?: array<string,mixed>,
+ *   show_in_rest?: bool,
  *   ability_class?: class-string<\WP_Ability>,
  *   ...<string, mixed>
  * } $args

--- a/includes/abilities-api/class-wp-abilities-registry.php
+++ b/includes/abilities-api/class-wp-abilities-registry.php
@@ -59,6 +59,7 @@ final class WP_Abilities_Registry {
 	 *   output_schema?: array<string,mixed>,
 	 *   annotations?: array<string,mixed>,
 	 *   meta?: array<string,mixed>,
+	 *   show_in_rest?: bool,
 	 *   ability_class?: class-string<\WP_Ability>,
 	 *   ...<string, mixed>
 	 * } $args

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -117,6 +117,14 @@ class WP_Ability {
 	protected $meta = array();
 
 	/**
+	 * Whether to show the ability in the REST API.
+	 *
+	 * @since n.e.x.t
+	 * @var bool
+	 */
+	protected $show_in_rest = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * Do not use this constructor directly. Instead, use the `wp_register_ability()` function.
@@ -128,9 +136,9 @@ class WP_Ability {
 	 * @see wp_register_ability()
 	 *
 	 * @param string              $name The name of the ability, with its namespace.
-	 * @param array<string,mixed> $args An associative array of arguments for the ability. This should
-	 *                                  include `label`, `description`, `input_schema`, `output_schema`,
-	 *                                  `execute_callback`, `permission_callback`, `annotations`, and `meta`.
+	 * @param array<string,mixed> $args An associative array of arguments for the ability. This should include
+	 *                                  `label`, `description`, `input_schema`, `output_schema`, `execute_callback`,
+	 *                                  `permission_callback`, `annotations`, `meta`, and `show_in_rest`.
 	 */
 	public function __construct( string $name, array $args ) {
 		$this->name = $name;
@@ -180,6 +188,7 @@ class WP_Ability {
 	 *   output_schema?: array<string,mixed>,
 	 *   annotations?: array<string,mixed>,
 	 *   meta?: array<string,mixed>,
+	 *   show_in_rest?: bool,
 	 *   ...<string, mixed>,
 	 * } $args
 	 */
@@ -231,6 +240,12 @@ class WP_Ability {
 		if ( isset( $args['meta'] ) && ! is_array( $args['meta'] ) ) {
 			throw new \InvalidArgumentException(
 				esc_html__( 'The ability properties should provide a valid `meta` array.' )
+			);
+		}
+
+		if ( isset( $args['show_in_rest'] ) && ! is_bool( $args['show_in_rest'] ) ) {
+			throw new \InvalidArgumentException(
+				esc_html__( 'The ability properties should provide a valid `show_in_rest` boolean.' )
 			);
 		}
 
@@ -319,6 +334,17 @@ class WP_Ability {
 	 */
 	public function get_meta(): array {
 		return $this->meta;
+	}
+
+	/**
+	 * Checks whether the ability should be shown in the REST API.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool True if the ability should be shown in the REST API, false otherwise.
+	 */
+	public function has_show_in_rest(): bool {
+		return $this->show_in_rest;
 	}
 
 	/**

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -343,7 +343,7 @@ class WP_Ability {
 	 *
 	 * @return bool True if the ability should be shown in the REST API, false otherwise.
 	 */
-	public function has_show_in_rest(): bool {
+	public function show_in_rest(): bool {
 		return $this->show_in_rest;
 	}
 

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
@@ -94,7 +94,12 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 	 * @return \WP_REST_Response Response object on success.
 	 */
 	public function get_items( $request ) {
-		$abilities = wp_get_abilities();
+		$abilities = array_filter(
+			wp_get_abilities(),
+			static function ( $ability ) {
+				return $ability->has_show_in_rest();
+			}
+		);
 
 		// Handle pagination with explicit defaults.
 		$params   = $request->get_params();
@@ -150,8 +155,7 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 	 */
 	public function get_item( $request ) {
 		$ability = wp_get_ability( $request->get_param( 'name' ) );
-
-		if ( ! $ability ) {
+		if ( ! $ability || ! $ability->has_show_in_rest() ) {
 			return new \WP_Error(
 				'rest_ability_not_found',
 				__( 'Ability not found.' ),

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-list-controller.php
@@ -97,7 +97,7 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 		$abilities = array_filter(
 			wp_get_abilities(),
 			static function ( $ability ) {
-				return $ability->has_show_in_rest();
+				return $ability->show_in_rest();
 			}
 		);
 
@@ -155,7 +155,7 @@ class WP_REST_Abilities_List_Controller extends WP_REST_Controller {
 	 */
 	public function get_item( $request ) {
 		$ability = wp_get_ability( $request->get_param( 'name' ) );
-		if ( ! $ability || ! $ability->has_show_in_rest() ) {
+		if ( ! $ability || ! $ability->show_in_rest() ) {
 			return new \WP_Error(
 				'rest_ability_not_found',
 				__( 'Ability not found.' ),

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
@@ -154,7 +154,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 	 */
 	public function run_ability_permissions_check( $request ) {
 		$ability = wp_get_ability( $request->get_param( 'name' ) );
-		if ( ! $ability ) {
+		if ( ! $ability || ! $ability->has_show_in_rest() ) {
 			return new \WP_Error(
 				'rest_ability_not_found',
 				__( 'Ability not found.' ),

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-run-controller.php
@@ -154,7 +154,7 @@ class WP_REST_Abilities_Run_Controller extends WP_REST_Controller {
 	 */
 	public function run_ability_permissions_check( $request ) {
 		$ability = wp_get_ability( $request->get_param( 'name' ) );
-		if ( ! $ability || ! $ability->has_show_in_rest() ) {
+		if ( ! $ability || ! $ability->show_in_rest() ) {
 			return new \WP_Error(
 				'rest_ability_not_found',
 				__( 'Ability not found.' ),

--- a/tests/unit/abilities-api/wpAbilitiesRegistry.php
+++ b/tests/unit/abilities-api/wpAbilitiesRegistry.php
@@ -62,6 +62,7 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 			'meta'                => array(
 				'category' => 'math',
 			),
+			'show_in_rest'        => true,
 		);
 	}
 
@@ -292,6 +293,21 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 */
 	public function test_register_invalid_meta_type() {
 		self::$test_ability_args['meta'] = false;
+
+		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_args );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Should reject ability registration with invalid show in REST type.
+	 *
+	 * @covers WP_Abilities_Registry::register
+	 * @covers WP_Ability::prepare_properties
+	 *
+	 * @expectedIncorrectUsage WP_Abilities_Registry::register
+	 */
+	public function test_register_invalid_show_in_rest_type() {
+		self::$test_ability_args['show_in_rest'] = 5;
 
 		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_args );
 		$this->assertNull( $result );

--- a/tests/unit/abilities-api/wpAbility.php
+++ b/tests/unit/abilities-api/wpAbility.php
@@ -36,9 +36,6 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 				'readonly'    => true,
 				'destructive' => false,
 			),
-			'meta'                => array(
-				'category' => 'math',
-			),
 		);
 	}
 

--- a/tests/unit/abilities-api/wpAbility.php
+++ b/tests/unit/abilities-api/wpAbility.php
@@ -98,6 +98,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 
 		$this->assertSame( $annotations, $ability->get_annotations() );
 	}
+
 	/**
 	 * Tests that invalid annotations throw an exception.
 	 */
@@ -113,6 +114,30 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 		$this->expectExceptionMessage( 'The ability properties should provide a valid `annotations` array.' );
 
 		new WP_Ability( self::$test_ability_name, $args );
+	}
+
+	/**
+	 * Tests that `show_in_rest` defaults to false when not provided.
+	 */
+	public function test_show_in_rest_defaults_to_false() {
+		$ability = new WP_Ability( self::$test_ability_name, self::$test_ability_properties );
+
+		$this->assertFalse( $ability->has_show_in_rest(), '`show_in_rest` should default to false.' );
+	}
+
+	/**
+	 * Tests that `show_in_rest` can be set to true.
+	 */
+	public function test_show_in_rest_can_be_set_to_true() {
+		$args = array_merge(
+			self::$test_ability_properties,
+			array(
+				'show_in_rest' => true,
+			)
+		);
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+
+		$this->assertTrue( $ability->has_show_in_rest(), '`show_in_rest` should be true.' );
 	}
 
 	/**

--- a/tests/unit/abilities-api/wpAbility.php
+++ b/tests/unit/abilities-api/wpAbility.php
@@ -100,7 +100,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that invalid annotations throw an exception.
+	 * Tests that invalid `annotations` value throws an exception.
 	 */
 	public function test_annotations_throws_exception() {
 		$args = array_merge(
@@ -122,7 +122,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	public function test_show_in_rest_defaults_to_false() {
 		$ability = new WP_Ability( self::$test_ability_name, self::$test_ability_properties );
 
-		$this->assertFalse( $ability->has_show_in_rest(), '`show_in_rest` should default to false.' );
+		$this->assertFalse( $ability->show_in_rest(), '`show_in_rest` should default to false.' );
 	}
 
 	/**
@@ -137,7 +137,24 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 		);
 		$ability = new WP_Ability( self::$test_ability_name, $args );
 
-		$this->assertTrue( $ability->has_show_in_rest(), '`show_in_rest` should be true.' );
+		$this->assertTrue( $ability->show_in_rest(), '`show_in_rest` should be true.' );
+	}
+
+	/**
+	 * Tests that invalid `show_in_rest` value throws an exception.
+	 */
+	public function test_show_in_rest_throws_exception() {
+		$args = array_merge(
+			self::$test_ability_properties,
+			array(
+				'show_in_rest' => 5,
+			)
+		);
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'The ability properties should provide a valid `show_in_rest` boolean.' );
+
+		new WP_Ability( self::$test_ability_name, $args );
 	}
 
 	/**

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -67,6 +67,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 			'meta'                => array(
 				'category' => 'math',
 			),
+			'show_in_rest'        => true,
 		);
 	}
 
@@ -147,6 +148,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 			$result->get_annotations()
 		);
 		$this->assertSame( self::$test_ability_args['meta'], $result->get_meta() );
+		$this->assertSame( self::$test_ability_args['show_in_rest'], $result->has_show_in_rest() );
 		$this->assertTrue(
 			$result->check_permissions(
 				array(

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -148,7 +148,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 			$result->get_annotations()
 		);
 		$this->assertSame( self::$test_ability_args['meta'], $result->get_meta() );
-		$this->assertSame( self::$test_ability_args['show_in_rest'], $result->has_show_in_rest() );
+		$this->assertSame( self::$test_ability_args['show_in_rest'], $result->show_in_rest() );
 		$this->assertTrue(
 			$result->check_permissions(
 				array(

--- a/tests/unit/rest-api/wpRestAbilitiesListController.php
+++ b/tests/unit/rest-api/wpRestAbilitiesListController.php
@@ -174,6 +174,19 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 			)
 		);
 
+		// Ability that does not show in REST.
+		wp_register_ability(
+			'test/not-show-in-rest',
+			array(
+				'label'               => 'Hidden from REST',
+				'description'         => 'It does not show in REST.',
+				'execute_callback'    => static function (): int {
+					return 0;
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
 		// Register multiple abilities for pagination testing
 		for ( $i = 1; $i <= 60; $i++ ) {
 			wp_register_ability(
@@ -209,6 +222,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 		$ability_names = wp_list_pluck( $data, 'name' );
 		$this->assertContains( 'test/calculator', $ability_names );
 		$this->assertContains( 'test/system-info', $ability_names );
+		$this->assertNotContains( 'test/not-show-in-rest', $ability_names );
 	}
 
 	/**
@@ -246,6 +260,19 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test getting an ability that does not show in REST returns 404.
+	 */
+	public function test_get_item_not_show_in_rest(): void {
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/abilities/test/not-show-in-rest' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertEquals( 'rest_ability_not_found', $data['code'] );
+	}
+
+	/**
 	 * Test permission check for listing abilities.
 	 */
 	public function test_get_items_permission_denied(): void {
@@ -272,7 +299,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'X-WP-Total', $headers );
 		$this->assertArrayHasKey( 'X-WP-TotalPages', $headers );
 
-		$total_abilities = count( wp_get_abilities() );
+		$total_abilities = count( wp_get_abilities() ) - 1; // Exclude the one that doesn't show in REST.
 		$this->assertEquals( $total_abilities, (int) $headers['X-WP-Total'] );
 		$this->assertEquals( ceil( $total_abilities / 10 ), (int) $headers['X-WP-TotalPages'] );
 	}

--- a/tests/unit/rest-api/wpRestAbilitiesListController.php
+++ b/tests/unit/rest-api/wpRestAbilitiesListController.php
@@ -124,6 +124,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 				'meta'                => array(
 					'category' => 'math',
 				),
+				'show_in_rest'        => true,
 			)
 		);
 
@@ -169,6 +170,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 				'meta'                => array(
 					'category' => 'system',
 				),
+				'show_in_rest'        => true,
 			)
 		);
 
@@ -183,6 +185,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 						return "Result from ability {$i}";
 					},
 					'permission_callback' => '__return_true',
+					'show_in_rest'        => true,
 				)
 			);
 		}
@@ -442,6 +445,7 @@ class Tests_REST_API_WpRestAbilitiesListController extends WP_UnitTestCase {
 					return array( 'success' => true );
 				},
 				'permission_callback' => '__return_true',
+				'show_in_rest'        => true,
 			)
 		);
 

--- a/tests/unit/rest-api/wpRestAbilitiesRunController.php
+++ b/tests/unit/rest-api/wpRestAbilitiesRunController.php
@@ -121,6 +121,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 				'permission_callback' => static function () {
 					return current_user_can( 'edit_posts' );
 				},
+				'show_in_rest'        => true,
 			)
 		);
 
@@ -163,6 +164,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 				'annotations'         => array(
 					'readonly' => true,
 				),
+				'show_in_rest'        => true,
 			)
 		);
 
@@ -190,6 +192,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					// Only allow if secret matches
 					return isset( $input['secret'] ) && 'valid_secret' === $input['secret'];
 				},
+				'show_in_rest'        => true,
 			)
 		);
 
@@ -203,6 +206,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return null;
 				},
 				'permission_callback' => '__return_true',
+				'show_in_rest'        => true,
 			)
 		);
 
@@ -216,6 +220,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return new \WP_Error( 'test_error', 'This is a test error' );
 				},
 				'permission_callback' => '__return_true',
+				'show_in_rest'        => true,
 			)
 		);
 
@@ -232,6 +237,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return 'not a number'; // Invalid - schema expects number
 				},
 				'permission_callback' => '__return_true',
+				'show_in_rest'        => true,
 			)
 		);
 
@@ -255,6 +261,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 				'annotations'         => array(
 					'readonly' => true,
 				),
+				'show_in_rest'        => true,
 			)
 		);
 	}
@@ -315,6 +322,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return 'success';
 				},
 				'permission_callback' => '__return_true',
+				'show_in_rest'        => true,
 			)
 		);
 
@@ -591,6 +599,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return array( 'wrong_field' => 'value' );
 				},
 				'permission_callback' => '__return_true',
+				'show_in_rest'        => true,
 			)
 		);
 
@@ -632,6 +641,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return array( 'status' => 'success' );
 				},
 				'permission_callback' => '__return_true',
+				'show_in_rest'        => true,
 			)
 		);
 
@@ -666,6 +676,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return array( 'executed' => true );
 				},
 				'permission_callback' => '__return_true',
+				'show_in_rest'        => true,
 			)
 		);
 
@@ -699,6 +710,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 				'annotations'         => array(
 					'readonly' => true,
 				),
+				'show_in_rest'        => true,
 			)
 		);
 
@@ -711,6 +723,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return array( 'input_was_empty' => 0 === func_num_args() );
 				},
 				'permission_callback' => '__return_true',
+				'show_in_rest'        => true,
 			)
 		);
 
@@ -783,6 +796,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return array( 'echo' => $input );
 				},
 				'permission_callback' => '__return_true',
+				'show_in_rest'        => true,
 			)
 		);
 
@@ -826,6 +840,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return array( 'echo' => $input );
 				},
 				'permission_callback' => '__return_true',
+				'show_in_rest'        => true,
 			)
 		);
 
@@ -885,6 +900,7 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 					return array( 'success' => true );
 				},
 				'permission_callback' => '__return_true', // No permission requirements
+				'show_in_rest'        => true,
 			)
 		);
 

--- a/tests/unit/rest-api/wpRestAbilitiesRunController.php
+++ b/tests/unit/rest-api/wpRestAbilitiesRunController.php
@@ -196,6 +196,19 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 			)
 		);
 
+		// Ability that does not show in REST.
+		wp_register_ability(
+			'test/not-show-in-rest',
+			array(
+				'label'               => 'Hidden from REST',
+				'description'         => 'It does not show in REST.',
+				'execute_callback'    => static function (): int {
+					return 0;
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
 		// Ability that returns null
 		wp_register_ability(
 			'test/null-return',
@@ -434,6 +447,21 @@ class Tests_REST_API_WpRestAbilitiesRunController extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'Success: test data', $response->get_data() );
+	}
+
+	/**
+	 * Test handling an ability that does not show in REST.
+	 */
+	public function test_do_not_show_in_rest(): void {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/abilities/test/not-show-in-rest/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( 'rest_ability_not_found', $data['code'] );
+		$this->assertEquals( 'Ability not found.', $data['message'] );
 	}
 
 	/**


### PR DESCRIPTION
Noted in #83.

Introduces `show_in_rest` arg in the server-side registry in the case devs don't want their abilities to be discoverable in REST API endpoints. By default, abilities won't get exposed which aligns with many other fundamental pieces in WordPress like post types, taxonomies, meta, etc.

It also adds a new method on `WP_Ability` object `show_in_rest()` to allow checking whether the ability should be exposed through REST API.

Example

```php
// Ability that does not show in REST.
$ability = wp_register_ability(
	'test/not-show-in-rest',
	array(
		'label'               => 'Hidden from REST',
		'description'         => 'It does not show in REST.',
		'execute_callback'    => static function (): int {
			return 0;
		},
		'permission_callback' => '__return_true',
	)
);
// false === $ability->show_in_rest() 


// Ability that shows in REST.
$ability = wp_register_ability(
	'test/show-in-rest',
	array(
		'label'               => 'Show in REST',
		'description'         => 'It shows in REST.',
		'execute_callback'    => static function (): int {
			return 0;
		},
		'permission_callback' => '__return_true',
		'show_in_rest' => true,
	)
);
// true === $ability->show_in_rest() 
```

### Testing

Run `npm run test:php` to execute extended test coverage for the new functionality.