### PR TITLE
Add Filtering Capabilities for Registered Abilities

### DIFF
--- a/docs/4.using-abilities.md
+++ b/docs/4.using-abilities.md
@@ -41,9 +41,10 @@ To get an array of all registered abilities:
 /**
  * Retrieves all registered abilities using Abilities API.
  *
+ * @param array $args Optional. Arguments to filter abilities.
  * @return WP_Ability[] The array of registered abilities.
  */
-function wp_get_abilities(): array
+function wp_get_abilities( array $args = array() ): array
 
 // Example: Get all registered abilities
 $all_abilities = wp_get_abilities();
@@ -55,6 +56,30 @@ foreach ( $all_abilities as $name => $ability ) {
     echo "---\n";
 }
 ```
+
+### Filtering Abilities
+
+`wp_get_abilities()` accepts optional filter arguments. For detailed filtering documentation, see [Querying and Filtering Abilities](8.querying-filtering-abilities.md).
+
+Quick example:
+
+```php
+// Get abilities in a specific category
+$abilities = wp_get_abilities( array( 'category' => 'data-retrieval' ) );
+
+// Search for abilities
+$abilities = wp_get_abilities( array( 'search' => 'email' ) );
+
+// Filter by namespace and meta
+$abilities = wp_get_abilities( array(
+    'namespace' => 'my-plugin',
+    'meta'      => array(
+        'show_in_rest' => true,
+    ),
+) );
+```
+
+See [Querying and Filtering Abilities](8.querying-filtering-abilities.md) for complete filtering documentation, including meta filters, ordering, and pagination.
 
 ## Executing an Ability (`$ability->execute()`)
 

--- a/docs/8.querying-filtering-abilities.md
+++ b/docs/8.querying-filtering-abilities.md
@@ -1,0 +1,213 @@
+# 8. Querying and Filtering Abilities
+
+The Abilities API provides powerful filtering capabilities through the `WP_Abilities_Query` class and the `wp_get_abilities()` function. This allows you to efficiently find and retrieve specific abilities from potentially thousands of registered abilities.
+
+`wp_get_abilities()` returns an array of `WP_Ability` objects, keyed by ability name.
+
+When no abilities match the query, an empty array is returned.
+
+Invalid query parameters are normalized to safe defaults.
+
+## Overview
+
+When working with large numbers of abilities registered by core and various plugins, the query system provides optimized server-side filtering. You can pass query arguments to `wp_get_abilities()` to filter abilities by category, namespace, meta properties, and more.
+
+```php
+// Get all abilities
+$abilities = wp_get_abilities();
+
+// Filter by category
+$abilities = wp_get_abilities( array( 'category' => 'data-retrieval' ) );
+
+// Combine multiple filters
+$abilities = wp_get_abilities( array(
+    'namespace' => 'my-plugin',
+    'category'  => 'communication',
+    'orderby'   => 'label',
+) );
+```
+
+## Quick Reference: Query Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `category` | string\|array | `''` | Filter by category slug. Accepts single value or array for multiple categories (OR logic) |
+| `namespace` | string\|array | `''` | Filter by namespace. Accepts single value or array for multiple namespaces (OR logic) |
+| `search` | string | `''` | Search in name, label, and description (case-insensitive) |
+| `meta` | array | `array()` | Filter by meta properties using nested arrays (AND logic between multiple meta filters) |
+| `orderby` | string | `''` | Sort by: `'name'`, `'label'`, or `'category'`. Empty = no sorting |
+| `order` | string | `'ASC'` | Sort direction: `'ASC'` or `'DESC'` |
+| `limit` | int | `-1` | Maximum results to return. `-1` = unlimited |
+| `offset` | int | `0` | Number of results to skip |
+
+## Basic Filtering
+
+### Filter by Category
+
+```php
+// Get all data retrieval abilities
+$abilities = wp_get_abilities( array( 'category' => 'data-retrieval' ) );
+
+// Get all communication abilities
+$abilities = wp_get_abilities( array( 'category' => 'communication' ) );
+
+// Get abilities from multiple categories (OR logic)
+$abilities = wp_get_abilities( array( 
+    'category' => array( 'math', 'communication', 'data-retrieval' ),
+) );
+```
+
+### Filter by Namespace
+
+Namespace is the part before the `/` in the ability name (e.g., `my-plugin` in `my-plugin/send-email`).
+
+```php
+// Get all abilities from your plugin
+$abilities = wp_get_abilities( array( 'namespace' => 'my-plugin' ) );
+
+// Get all WooCommerce abilities
+$abilities = wp_get_abilities( array( 'namespace' => 'woocommerce' ) );
+
+// Get abilities from multiple namespaces (OR logic)
+$abilities = wp_get_abilities( array(
+    'namespace' => array( 'my-plugin', 'woocommerce', 'jetpack' ),
+) );
+```
+
+### Search Abilities
+
+Search is case-insensitive and searches in name, label, and description:
+
+```php
+// Find all abilities related to email
+$abilities = wp_get_abilities( array( 'search' => 'email' ) );
+
+// Find payment-related abilities
+$abilities = wp_get_abilities( array( 'search' => 'payment' ) );
+```
+
+### Combine Multiple Filters
+
+Filters are cumulative (AND logic):
+
+```php
+// Get communication abilities from my-plugin only
+$abilities = wp_get_abilities( array(
+    'category'  => 'communication',
+    'namespace' => 'my-plugin',
+) );
+
+// Search for email abilities in the communication category
+$abilities = wp_get_abilities( array(
+    'category' => 'communication',
+    'search'   => 'email',
+) );
+```
+
+## Meta Filtering
+
+Filter abilities by their meta properties, including `show_in_rest`, `annotations`, and custom meta keys. All meta filters use AND logic — abilities must match all specified criteria.
+
+### Filter by REST API Visibility
+
+```php
+// Get abilities exposed in REST API
+$abilities = wp_get_abilities( array(
+    'meta' => array(
+        'show_in_rest' => true,
+    ),
+) );
+
+// Get abilities hidden from REST API
+$abilities = wp_get_abilities( array(
+    'meta' => array(
+        'show_in_rest' => false,
+    ),
+) );
+```
+
+### Filter by Annotations
+
+```php
+// Get readonly abilities
+$abilities = wp_get_abilities( array(
+    'meta' => array(
+        'annotations' => array(
+            'readonly' => true,
+        ),
+    ),
+) );
+
+// Get non-destructive, idempotent abilities
+$abilities = wp_get_abilities( array(
+    'meta' => array(
+        'annotations' => array(
+            'destructive' => false,
+            'idempotent'  => true,
+        ),
+    ),
+) );
+```
+
+### Combine Multiple Meta Filters
+
+When you specify multiple meta conditions, abilities must match all of them (AND logic):
+
+```php
+// Get readonly abilities that are exposed in REST API
+$abilities = wp_get_abilities( array(
+    'meta' => array(
+        'show_in_rest' => true,
+        'annotations'  => array(
+            'readonly' => true,
+        ),
+    ),
+) );
+
+// Get REST-enabled, readonly, idempotent abilities
+$abilities = wp_get_abilities( array(
+    'meta' => array(
+        'show_in_rest' => true,
+        'annotations'  => array(
+            'readonly'   => true,
+            'idempotent' => true,
+        ),
+    ),
+) );
+```
+
+### Filter by Custom Meta
+
+You can filter by any custom meta keys you've added to abilities:
+
+```php
+$abilities = wp_get_abilities( array(
+    'meta' => array(
+        'custom_key'   => 'custom_value',
+        'another_meta' => 'another_value',
+    ),
+) );
+```
+
+## Ordering and Pagination
+
+```php
+// Order by name, label, or category
+$abilities = wp_get_abilities( array(
+    'orderby' => 'label',
+    'order'   => 'ASC', // or 'DESC'
+) );
+
+// Paginate results
+$abilities = wp_get_abilities( array(
+    'limit'  => 10,
+    'offset' => 0,
+) );
+```
+
+## See Also
+
+- [Registering Abilities](3.registering-abilities.md) - How to register abilities with proper metadata
+- [Using Abilities](4.using-abilities.md) - Basic ability usage, execution, and permissions
+- [Registering Categories](7.registering-categories.md) - How to register ability categories
+- [REST API](5.rest-api.md) - REST API endpoints for abilities

--- a/includes/abilities-api.php
+++ b/includes/abilities-api.php
@@ -95,13 +95,38 @@ function wp_get_ability( string $name ): ?WP_Ability {
  * Retrieves all registered abilities using Abilities API.
  *
  * @since 0.1.0
+ * @since n.e.x.t Added optional $args parameter for filtering abilities.
  *
  * @see WP_Abilities_Registry::get_all_registered()
+ * @see WP_Abilities_Query
  *
+ * @param array<string,mixed> $args Optional. Arguments to filter abilities. Default empty array.
+ *                                   Accepts 'category', 'namespace', 'search', 'meta', 'orderby',
+ *                                   'order', 'limit', and 'offset'.
+ *                                   'category' and 'namespace' accept string or array for multi-value filtering.
+ *                                   All filters use AND logic between different filter types and meta properties.
  * @return \WP_Ability[] The array of registered abilities.
+ *
+ * @phpstan-param array{
+ *   category?: string|string[],
+ *   namespace?: string|string[],
+ *   search?: string,
+ *   meta?: array<string,mixed>,
+ *   orderby?: string,
+ *   order?: string,
+ *   limit?: int,
+ *   offset?: int,
+ *   ...<string, mixed>
+ * } $args
  */
-function wp_get_abilities(): array {
-	return WP_Abilities_Registry::get_instance()->get_all_registered();
+function wp_get_abilities( array $args = array() ): array {
+	if ( empty( $args ) ) {
+		// Backward compatibility: return all abilities if no args.
+		return WP_Abilities_Registry::get_instance()->get_all_registered();
+	}
+
+	$query = new WP_Abilities_Query( $args );
+	return $query->get_abilities();
 }
 
 /**

--- a/includes/abilities-api.php
+++ b/includes/abilities-api.php
@@ -94,10 +94,11 @@ function wp_get_ability( string $name ): ?WP_Ability {
 /**
  * Retrieves all registered abilities using Abilities API.
  *
+ * Uses WP_Abilities_Query to retrieve abilities from the registry with optional filtering.
+ *
  * @since 0.1.0
  * @since n.e.x.t Added optional $args parameter for filtering abilities.
  *
- * @see WP_Abilities_Registry::get_all_registered()
  * @see WP_Abilities_Query
  *
  * @param array<string,mixed> $args Optional. Arguments to filter abilities. Default empty array.

--- a/includes/abilities-api.php
+++ b/includes/abilities-api.php
@@ -100,6 +100,7 @@ function wp_get_ability( string $name ): ?WP_Ability {
  * @since n.e.x.t Added optional $args parameter for filtering abilities.
  *
  * @see WP_Abilities_Query
+ * @see WP_Abilities_Query::AbilityQueryArgs for the full type definition.
  *
  * @param array<string,mixed> $args Optional. Arguments to filter abilities. Default empty array.
  *                                   Accepts 'category', 'namespace', 'search', 'meta', 'orderby',

--- a/includes/abilities-api.php
+++ b/includes/abilities-api.php
@@ -108,8 +108,8 @@ function wp_get_ability( string $name ): ?WP_Ability {
  * @return \WP_Ability[] The array of registered abilities.
  *
  * @phpstan-param array{
- *   category?: string|string[],
- *   namespace?: string|string[],
+ *   category?: string|array<string>,
+ *   namespace?: string|array<string>,
  *   search?: string,
  *   meta?: array<string,mixed>,
  *   orderby?: string,

--- a/includes/abilities-api.php
+++ b/includes/abilities-api.php
@@ -120,11 +120,6 @@ function wp_get_ability( string $name ): ?WP_Ability {
  * } $args
  */
 function wp_get_abilities( array $args = array() ): array {
-	if ( empty( $args ) ) {
-		// Backward compatibility: return all abilities if no args.
-		return WP_Abilities_Registry::get_instance()->get_all_registered();
-	}
-
 	$query = new WP_Abilities_Query( $args );
 	return $query->get_abilities();
 }

--- a/includes/abilities-api/class-wp-abilities-query.php
+++ b/includes/abilities-api/class-wp-abilities-query.php
@@ -85,7 +85,7 @@ class WP_Abilities_Query {
 	}
 
 	/**
-	 * Parses and validates query arguments.
+	 * Parses and sanitizes query arguments.
 	 *
 	 * @since n.e.x.t
 	 *
@@ -106,19 +106,19 @@ class WP_Abilities_Query {
 
 		$this->query_vars = wp_parse_args( $args, $defaults );
 
-		$this->validate_meta_arg();
-		$this->validate_orderby();
-		$this->validate_order();
-		$this->validate_pagination_args();
+		$this->sanitize_meta_arg();
+		$this->sanitize_orderby();
+		$this->sanitize_order();
+		$this->sanitize_pagination_args();
 	}
 
 	/**
-	 * Validates the meta query argument.
+	 * Sanitizes the meta query argument.
 	 *
 	 * @since n.e.x.t
 	 *
 	 */
-	protected function validate_meta_arg(): void {
+	protected function sanitize_meta_arg(): void {
 		if ( is_array( $this->query_vars['meta'] ) ) {
 			return;
 		}
@@ -126,12 +126,12 @@ class WP_Abilities_Query {
 	}
 
 	/**
-	 * Validates the orderby query argument.
+	 * Sanitizes the orderby query argument.
 	 *
 	 * @since n.e.x.t
 	 *
 	 */
-	protected function validate_orderby(): void {
+	protected function sanitize_orderby(): void {
 		if ( empty( $this->query_vars['orderby'] ) ) {
 			return;
 		}
@@ -143,12 +143,12 @@ class WP_Abilities_Query {
 	}
 
 	/**
-	 * Validates the order query argument.
+	 * Sanitizes the order query argument.
 	 *
 	 * @since n.e.x.t
 	 *
 	 */
-	protected function validate_order(): void {
+	protected function sanitize_order(): void {
 		$this->query_vars['order'] = strtoupper( $this->query_vars['order'] );
 		if ( in_array( $this->query_vars['order'], self::$valid_order_directions, true ) ) {
 			return;
@@ -157,12 +157,12 @@ class WP_Abilities_Query {
 	}
 
 	/**
-	 * Validates the pagination query arguments (limit and offset).
+	 * Sanitizes the pagination query arguments (limit and offset).
 	 *
 	 * @since n.e.x.t
 	 *
 	 */
-	protected function validate_pagination_args(): void {
+	protected function sanitize_pagination_args(): void {
 		$this->query_vars['limit']  = (int) $this->query_vars['limit'];
 		$this->query_vars['offset'] = (int) $this->query_vars['offset'];
 	}

--- a/includes/abilities-api/class-wp-abilities-query.php
+++ b/includes/abilities-api/class-wp-abilities-query.php
@@ -95,7 +95,6 @@ final class WP_Abilities_Query {
 	 * @since n.e.x.t
 	 *
 	 * @param array<string,mixed> $args Query arguments.
-	 *
 	 */
 	protected function parse_query( array $args ): void {
 		$defaults = array(

--- a/includes/abilities-api/class-wp-abilities-query.php
+++ b/includes/abilities-api/class-wp-abilities-query.php
@@ -22,12 +22,20 @@ declare( strict_types=1 );
 class WP_Abilities_Query {
 
 	/**
+	 * Constant representing no limit on results.
+	 *
+	 * @since n.e.x.t
+	 * @var int
+	 */
+	private static $no_limit = -1;
+
+	/**
 	 * Valid orderby fields.
 	 *
 	 * @since n.e.x.t
 	 * @var array<string>
 	 */
-	public const VALID_ORDERBY_FIELDS = array( 'name', 'label', 'category' );
+	private static $valid_orderby_fields = array( 'name', 'label', 'category' );
 
 	/**
 	 * Valid order directions.
@@ -35,15 +43,7 @@ class WP_Abilities_Query {
 	 * @since n.e.x.t
 	 * @var array<string>
 	 */
-	public const VALID_ORDER_DIRECTIONS = array( 'ASC', 'DESC' );
-
-	/**
-	 * Constant representing no limit on results.
-	 *
-	 * @since n.e.x.t
-	 * @var int
-	 */
-	public const NO_LIMIT = -1;
+	private static $valid_order_directions = array( 'ASC', 'DESC' );
 
 	/**
 	 * Query arguments after parsing.
@@ -51,7 +51,7 @@ class WP_Abilities_Query {
 	 * @since n.e.x.t
 	 * @var array<string,mixed>
 	 */
-	protected array $query_vars = array();
+	protected $query_vars = array();
 
 	/**
 	 * The filtered abilities result.
@@ -59,7 +59,7 @@ class WP_Abilities_Query {
 	 * @since n.e.x.t
 	 * @var \WP_Ability[]|null
 	 */
-	protected ?array $abilities = null;
+	protected $abilities = null;
 
 	/**
 	 * Constructor.
@@ -100,7 +100,7 @@ class WP_Abilities_Query {
 			'meta'      => array(),
 			'orderby'   => '',
 			'order'     => 'ASC',
-			'limit'     => self::NO_LIMIT,
+			'limit'     => self::$no_limit,
 			'offset'    => 0,
 		);
 
@@ -119,9 +119,10 @@ class WP_Abilities_Query {
 	 *
 	 */
 	protected function validate_meta_arg(): void {
-		if ( ! is_array( $this->query_vars['meta'] ) ) {
-			$this->query_vars['meta'] = array();
+		if ( is_array( $this->query_vars['meta'] ) ) {
+			return;
 		}
+		$this->query_vars['meta'] = array();
 	}
 
 	/**
@@ -135,9 +136,10 @@ class WP_Abilities_Query {
 			return;
 		}
 
-		if ( ! in_array( $this->query_vars['orderby'], self::VALID_ORDERBY_FIELDS, true ) ) {
-			$this->query_vars['orderby'] = '';
+		if ( in_array( $this->query_vars['orderby'], self::$valid_orderby_fields, true ) ) {
+			return;
 		}
+		$this->query_vars['orderby'] = '';
 	}
 
 	/**
@@ -148,9 +150,10 @@ class WP_Abilities_Query {
 	 */
 	protected function validate_order(): void {
 		$this->query_vars['order'] = strtoupper( $this->query_vars['order'] );
-		if ( ! in_array( $this->query_vars['order'], self::VALID_ORDER_DIRECTIONS, true ) ) {
-			$this->query_vars['order'] = 'ASC';
+		if ( in_array( $this->query_vars['order'], self::$valid_order_directions, true ) ) {
+			return;
 		}
+		$this->query_vars['order'] = 'ASC';
 	}
 
 	/**
@@ -291,15 +294,8 @@ class WP_Abilities_Query {
 
 		[ $flat_filters, $nested_filters ] = $this->separate_meta_filters( $filters );
 
-		if ( ! $this->check_flat_meta_filters( $ability_meta, $flat_filters ) ) {
-			return false;
-		}
-
-		if ( ! $this->check_nested_meta_filters( $ability_meta, $nested_filters ) ) {
-			return false;
-		}
-
-		return true;
+		return $this->check_flat_meta_filters( $ability_meta, $flat_filters )
+			&& $this->check_nested_meta_filters( $ability_meta, $nested_filters );
 	}
 
 	/**
@@ -315,8 +311,8 @@ class WP_Abilities_Query {
 		$search = $this->query_vars['search'];
 
 		return stripos( $ability->get_name(), $search ) !== false
-		       || stripos( $ability->get_label(), $search ) !== false
-		       || stripos( $ability->get_description(), $search ) !== false;
+			|| stripos( $ability->get_label(), $search ) !== false
+			|| stripos( $ability->get_description(), $search ) !== false;
 	}
 
 	/**
@@ -487,7 +483,7 @@ class WP_Abilities_Query {
 		$offset = $this->query_vars['offset'];
 
 		// No pagination if limit is -1.
-		if ( self::NO_LIMIT === $limit ) {
+		if ( self::$no_limit === $limit ) {
 			// Apply offset only if specified.
 			if ( $offset > 0 ) {
 				return array_slice( $abilities, $offset );

--- a/includes/abilities-api/class-wp-abilities-query.php
+++ b/includes/abilities-api/class-wp-abilities-query.php
@@ -18,6 +18,18 @@ declare( strict_types=1 );
  * including category, namespace, search terms, meta properties, and annotations.
  *
  * @since n.e.x.t
+ *
+ * @phpstan-type AbilityQueryArgs array{
+ *   category?: string|array<string>,
+ *   namespace?: string|array<string>,
+ *   search?: string,
+ *   meta?: array<string,mixed>,
+ *   orderby?: string,
+ *   order?: string,
+ *   limit?: int,
+ *   offset?: int,
+ *   ...<string, mixed>
+ * }
  */
 class WP_Abilities_Query {
 
@@ -66,19 +78,7 @@ class WP_Abilities_Query {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param array<string,mixed> $args Optional. Query arguments. Default empty array.
-	 *
-	 * @phpstan-param array{
-	 *   category?: string|array<string>,
-	 *   namespace?: string|array<string>,
-	 *   search?: string,
-	 *   meta?: array<string,mixed>,
-	 *   orderby?: string,
-	 *   order?: string,
-	 *   limit?: int,
-	 *   offset?: int,
-	 *   ...<string, mixed>
-	 * } $args
+	 * @param AbilityQueryArgs $args Optional. Query arguments. Default empty array.
 	 */
 	public function __construct( array $args = array() ) {
 		$this->parse_query( $args );

--- a/includes/abilities-api/class-wp-abilities-query.php
+++ b/includes/abilities-api/class-wp-abilities-query.php
@@ -172,9 +172,11 @@ class WP_Abilities_Query {
 		}
 
 		// Ensure limit is either -1 (no limit) or positive.
-		if ( $this->query_vars['limit'] < self::$no_limit ) {
-			$this->query_vars['limit'] = self::$no_limit;
+		if ( $this->query_vars['limit'] >= self::$no_limit ) {
+			return;
 		}
+
+		$this->query_vars['limit'] = self::$no_limit;
 	}
 
 	/**

--- a/includes/abilities-api/class-wp-abilities-query.php
+++ b/includes/abilities-api/class-wp-abilities-query.php
@@ -17,7 +17,12 @@ declare( strict_types=1 );
  * Provides a WordPress-standard query interface for filtering abilities by various criteria,
  * including category, namespace, search terms, meta properties, and annotations.
  *
+ * This class is not intended to be extended or consumed directly. Use the wp_get_abilities()
+ * function instead, which provides a stable public API for querying abilities.
+ *
  * @since n.e.x.t
+ *
+ * @internal
  *
  * @phpstan-type AbilityQueryArgs array{
  *   category?: string|array<string>,
@@ -31,7 +36,7 @@ declare( strict_types=1 );
  *   ...<string, mixed>
  * }
  */
-class WP_Abilities_Query {
+final class WP_Abilities_Query {
 
 	/**
 	 * Constant representing no limit on results.

--- a/includes/abilities-api/class-wp-abilities-query.php
+++ b/includes/abilities-api/class-wp-abilities-query.php
@@ -1,0 +1,519 @@
+<?php
+/**
+ * Abilities API
+ *
+ * Defines WP_Abilities_Query class.
+ *
+ * @package WordPress
+ * @subpackage Abilities API
+ * @since n.e.x.t
+ */
+
+declare( strict_types=1 );
+
+/**
+ * Query class for filtering registered abilities.
+ *
+ * Provides a WordPress-standard query interface for filtering abilities by various criteria,
+ * including category, namespace, search terms, meta properties, and annotations.
+ *
+ * @since n.e.x.t
+ */
+class WP_Abilities_Query {
+
+	/**
+	 * Valid orderby fields.
+	 *
+	 * @since n.e.x.t
+	 * @var array<string>
+	 */
+	public const VALID_ORDERBY_FIELDS = array( 'name', 'label', 'category' );
+
+	/**
+	 * Valid order directions.
+	 *
+	 * @since n.e.x.t
+	 * @var array<string>
+	 */
+	public const VALID_ORDER_DIRECTIONS = array( 'ASC', 'DESC' );
+
+	/**
+	 * Constant representing no limit on results.
+	 *
+	 * @since n.e.x.t
+	 * @var int
+	 */
+	public const NO_LIMIT = -1;
+
+	/**
+	 * Query arguments after parsing.
+	 *
+	 * @since n.e.x.t
+	 * @var array<string,mixed>
+	 */
+	protected array $query_vars = array();
+
+	/**
+	 * The filtered abilities result.
+	 *
+	 * @since n.e.x.t
+	 * @var \WP_Ability[]|null
+	 */
+	protected ?array $abilities = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array<string,mixed> $args Optional. Query arguments. Default empty array.
+	 *
+	 * @phpstan-param array{
+	 *   category?: string|array<string>,
+	 *   namespace?: string|array<string>,
+	 *   search?: string,
+	 *   meta?: array<string,mixed>,
+	 *   orderby?: string,
+	 *   order?: string,
+	 *   limit?: int,
+	 *   offset?: int,
+	 *   ...<string, mixed>
+	 * } $args
+	 */
+	public function __construct( array $args = array() ) {
+		$this->parse_query( $args );
+	}
+
+	/**
+	 * Parses and validates query arguments.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array<string,mixed> $args Query arguments.
+	 *
+	 */
+	protected function parse_query( array $args ): void {
+		$defaults = array(
+			'category'  => '',
+			'namespace' => '',
+			'search'    => '',
+			'meta'      => array(),
+			'orderby'   => '',
+			'order'     => 'ASC',
+			'limit'     => self::NO_LIMIT,
+			'offset'    => 0,
+		);
+
+		$this->query_vars = wp_parse_args( $args, $defaults );
+
+		$this->validate_meta_arg();
+		$this->validate_orderby();
+		$this->validate_order();
+		$this->validate_pagination_args();
+	}
+
+	/**
+	 * Validates the meta query argument.
+	 *
+	 * @since n.e.x.t
+	 *
+	 */
+	protected function validate_meta_arg(): void {
+		if ( ! is_array( $this->query_vars['meta'] ) ) {
+			$this->query_vars['meta'] = array();
+		}
+	}
+
+	/**
+	 * Validates the orderby query argument.
+	 *
+	 * @since n.e.x.t
+	 *
+	 */
+	protected function validate_orderby(): void {
+		if ( empty( $this->query_vars['orderby'] ) ) {
+			return;
+		}
+
+		if ( ! in_array( $this->query_vars['orderby'], self::VALID_ORDERBY_FIELDS, true ) ) {
+			$this->query_vars['orderby'] = '';
+		}
+	}
+
+	/**
+	 * Validates the order query argument.
+	 *
+	 * @since n.e.x.t
+	 *
+	 */
+	protected function validate_order(): void {
+		$this->query_vars['order'] = strtoupper( $this->query_vars['order'] );
+		if ( ! in_array( $this->query_vars['order'], self::VALID_ORDER_DIRECTIONS, true ) ) {
+			$this->query_vars['order'] = 'ASC';
+		}
+	}
+
+	/**
+	 * Validates the pagination query arguments (limit and offset).
+	 *
+	 * @since n.e.x.t
+	 *
+	 */
+	protected function validate_pagination_args(): void {
+		$this->query_vars['limit']  = (int) $this->query_vars['limit'];
+		$this->query_vars['offset'] = (int) $this->query_vars['offset'];
+	}
+
+	/**
+	 * Retrieves the filtered abilities based on query arguments.
+	 *
+	 * @return \WP_Ability[] Array of filtered abilities.
+	 * @since n.e.x.t
+	 *
+	 */
+	public function get_abilities(): array {
+		if ( null !== $this->abilities ) {
+			return $this->abilities;
+		}
+
+		$abilities = WP_Abilities_Registry::get_instance()->get_all_registered();
+
+		$abilities = $this->apply_filters( $abilities );
+
+		if ( empty( $abilities ) ) {
+			$this->abilities = array();
+
+			return $this->abilities;
+		}
+
+		$abilities = $this->apply_ordering( $abilities );
+
+		$abilities = $this->apply_pagination( $abilities );
+
+		$this->abilities = $abilities;
+
+		return $this->abilities;
+	}
+
+	/**
+	 * Applies all filters in a single pass for optimal performance.
+	 *
+	 * @param \WP_Ability[] $abilities Abilities to filter.
+	 *
+	 * @return \WP_Ability[] Filtered abilities.
+	 * @since n.e.x.t
+	 *
+	 */
+	protected function apply_filters( array $abilities ): array {
+		$has_category  = ! empty( $this->query_vars['category'] );
+		$has_namespace = ! empty( $this->query_vars['namespace'] );
+		$has_search    = ! empty( $this->query_vars['search'] );
+		$has_meta      = ! empty( $this->query_vars['meta'] ) && is_array( $this->query_vars['meta'] );
+
+		if ( ! $has_category && ! $has_namespace && ! $has_search && ! $has_meta ) {
+			return $abilities;
+		}
+
+		$filtered = array();
+
+		foreach ( $abilities as $name => $ability ) {
+			if ( $has_category && ! $this->filter_by_category( $ability ) ) {
+				continue;
+			}
+
+			if ( $has_namespace && ! $this->filter_by_namespace( $ability ) ) {
+				continue;
+			}
+
+			if ( $has_meta && ! $this->filter_by_meta( $ability ) ) {
+				continue;
+			}
+
+			if ( $has_search && ! $this->filter_by_search( $ability ) ) {
+				continue;
+			}
+
+			$filtered[ $name ] = $ability;
+		}
+
+		return $filtered;
+	}
+
+	/**
+	 * Checks if an ability matches the category filter.
+	 *
+	 * @param \WP_Ability $ability The ability to check.
+	 *
+	 * @return bool True if ability matches category filter, false otherwise.
+	 * @since n.e.x.t
+	 *
+	 */
+	protected function filter_by_category( WP_Ability $ability ): bool {
+		return $this->matches_filter( $ability->get_category(), $this->query_vars['category'] );
+	}
+
+	/**
+	 * Checks if an ability matches the namespace filter.
+	 *
+	 * @param \WP_Ability $ability The ability to check.
+	 *
+	 * @return bool True if ability matches namespace filter, false otherwise.
+	 * @since n.e.x.t
+	 *
+	 */
+	protected function filter_by_namespace( WP_Ability $ability ): bool {
+		$ability_namespace = self::get_ability_namespace( $ability->get_name() );
+
+		if ( null === $ability_namespace ) {
+			return false;
+		}
+
+		return $this->matches_filter( $ability_namespace, $this->query_vars['namespace'] );
+	}
+
+	/**
+	 * Checks if an ability matches the meta filters.
+	 *
+	 * @param \WP_Ability $ability The ability to check.
+	 *
+	 * @return bool True if ability matches meta filters, false otherwise.
+	 * @since n.e.x.t
+	 *
+	 */
+	protected function filter_by_meta( WP_Ability $ability ): bool {
+		$filters = $this->query_vars['meta'];
+
+		if ( empty( $filters ) ) {
+			return true;
+		}
+
+		$ability_meta = $ability->get_meta();
+
+		[ $flat_filters, $nested_filters ] = $this->separate_meta_filters( $filters );
+
+		if ( ! $this->check_flat_meta_filters( $ability_meta, $flat_filters ) ) {
+			return false;
+		}
+
+		if ( ! $this->check_nested_meta_filters( $ability_meta, $nested_filters ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks if an ability matches the search term.
+	 *
+	 * @param \WP_Ability $ability The ability to check.
+	 *
+	 * @return bool True if ability matches search term, false otherwise.
+	 * @since n.e.x.t
+	 *
+	 */
+	protected function filter_by_search( WP_Ability $ability ): bool {
+		$search = $this->query_vars['search'];
+
+		return stripos( $ability->get_name(), $search ) !== false
+		       || stripos( $ability->get_label(), $search ) !== false
+		       || stripos( $ability->get_description(), $search ) !== false;
+	}
+
+	/**
+	 * Checks if a value matches the filter (either equals or in array).
+	 *
+	 * @param string               $value  The value to check.
+	 * @param string|array<string> $filter The filter to match against.
+	 *
+	 * @return bool True if value matches the filter, false otherwise.
+	 * @since n.e.x.t
+	 *
+	 */
+	protected function matches_filter( string $value, $filter ): bool {
+		if ( is_array( $filter ) ) {
+			return in_array( $value, $filter, true );
+		}
+
+		return $value === $filter;
+	}
+
+	/**
+	 * Extracts the namespace from an ability name.
+	 *
+	 * @param string $ability_name The ability name (e.g., 'namespace/ability-name').
+	 *
+	 * @return string|null The namespace part, or null if no slash found.
+	 * @since n.e.x.t
+	 *
+	 */
+	protected static function get_ability_namespace( string $ability_name ): ?string {
+		$slash_pos = strpos( $ability_name, '/' );
+
+		if ( false === $slash_pos ) {
+			return null;
+		}
+
+		return substr( $ability_name, 0, $slash_pos );
+	}
+
+	/**
+	 * Separates meta filters into flat and nested arrays.
+	 *
+	 * @param array<string,mixed> $filters The meta filters to separate.
+	 *
+	 * @return array{0: array<string,mixed>, 1: array<string,mixed>} Array containing flat filters and nested filters.
+	 * @since n.e.x.t
+	 *
+	 */
+	protected function separate_meta_filters( array $filters ): array {
+		$flat_filters   = array();
+		$nested_filters = array();
+
+		foreach ( $filters as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$nested_filters[ $key ] = $value;
+			} else {
+				$flat_filters[ $key ] = $value;
+			}
+		}
+
+		return array( $flat_filters, $nested_filters );
+	}
+
+	/**
+	 * Checks if ability meta matches flat filters.
+	 *
+	 * @param array<string,mixed> $ability_meta The ability's meta data.
+	 * @param array<string,mixed> $flat_filters The flat filters to match.
+	 *
+	 * @return bool True if meta matches all flat filters, false otherwise.
+	 * @since n.e.x.t
+	 *
+	 */
+	protected function check_flat_meta_filters( array $ability_meta, array $flat_filters ): bool {
+		if ( empty( $flat_filters ) ) {
+			return true;
+		}
+
+		$flat_filtered = wp_list_filter( array( $ability_meta ), $flat_filters );
+
+		return ! empty( $flat_filtered );
+	}
+
+	/**
+	 * Checks if ability meta matches nested filters.
+	 *
+	 * @param array<string,mixed> $ability_meta   The ability's meta data.
+	 * @param array<string,mixed> $nested_filters The nested filters to match.
+	 *
+	 * @return bool True if meta matches all nested filters, false otherwise.
+	 * @since n.e.x.t
+	 *
+	 */
+	protected function check_nested_meta_filters( array $ability_meta, array $nested_filters ): bool {
+		if ( empty( $nested_filters ) ) {
+			return true;
+		}
+
+		foreach ( $nested_filters as $key => $nested_filter ) {
+			if ( ! isset( $ability_meta[ $key ] ) || ! is_array( $ability_meta[ $key ] ) ) {
+				return false;
+			}
+
+			$nested_filtered = wp_list_filter( array( $ability_meta[ $key ] ), $nested_filter );
+			if ( empty( $nested_filtered ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Applies ordering to abilities.
+	 *
+	 * @param \WP_Ability[] $abilities Abilities to order.
+	 *
+	 * @return \WP_Ability[] Ordered abilities.
+	 * @since n.e.x.t
+	 *
+	 */
+	protected function apply_ordering( array $abilities ): array {
+		$orderby = $this->query_vars['orderby'];
+
+		if ( empty( $orderby ) ) {
+			return $abilities;
+		}
+
+		$order = $this->query_vars['order'];
+
+		// Map orderby field to getter method name.
+		$getter_map = array(
+			'name'     => 'get_name',
+			'label'    => 'get_label',
+			'category' => 'get_category',
+		);
+
+		if ( ! isset( $getter_map[ $orderby ] ) ) {
+			return $abilities;
+		}
+
+		$getter_method    = $getter_map[ $orderby ];
+		$order_multiplier = 'DESC' === $order ? - 1 : 1;
+
+		$abilities = array_values( $abilities );
+
+		usort(
+			$abilities,
+			static function ( $a, $b ) use ( $getter_method, $order_multiplier ) {
+				return strcasecmp( $a->$getter_method(), $b->$getter_method() ) * $order_multiplier;
+			}
+		);
+
+		return $abilities;
+	}
+
+	/**
+	 * Applies pagination to abilities.
+	 *
+	 * @param \WP_Ability[] $abilities Abilities to paginate.
+	 *
+	 * @return \WP_Ability[] Paginated abilities.
+	 * @since n.e.x.t
+	 *
+	 */
+	protected function apply_pagination( array $abilities ): array {
+		$limit  = $this->query_vars['limit'];
+		$offset = $this->query_vars['offset'];
+
+		// No pagination if limit is -1.
+		if ( self::NO_LIMIT === $limit ) {
+			// Apply offset only if specified.
+			if ( $offset > 0 ) {
+				return array_slice( $abilities, $offset );
+			}
+
+			return $abilities;
+		}
+
+		// Apply offset and limit.
+		return array_slice( $abilities, $offset, $limit );
+	}
+
+	/**
+	 * Gets the query variables.
+	 *
+	 * @param string $key Optional. Specific query var to retrieve. Default empty string.
+	 *
+	 * @return mixed Query var value if key provided, all query vars if no key.
+	 * @since n.e.x.t
+	 *
+	 */
+	public function get( string $key = '' ) {
+		if ( ! empty( $key ) ) {
+			return $this->query_vars[ $key ] ?? null;
+		}
+
+		return $this->query_vars;
+	}
+}

--- a/includes/abilities-api/class-wp-abilities-query.php
+++ b/includes/abilities-api/class-wp-abilities-query.php
@@ -165,6 +165,16 @@ class WP_Abilities_Query {
 	protected function sanitize_pagination_args(): void {
 		$this->query_vars['limit']  = (int) $this->query_vars['limit'];
 		$this->query_vars['offset'] = (int) $this->query_vars['offset'];
+
+		// Ensure offset is non-negative.
+		if ( $this->query_vars['offset'] < 0 ) {
+			$this->query_vars['offset'] = 0;
+		}
+
+		// Ensure limit is either -1 (no limit) or positive.
+		if ( $this->query_vars['limit'] < self::$no_limit ) {
+			$this->query_vars['limit'] = self::$no_limit;
+		}
 	}
 
 	/**

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -35,6 +35,9 @@ if ( ! class_exists( 'WP_Ability_Category' ) ) {
 if ( ! class_exists( 'WP_Abilities_Category_Registry' ) ) {
 	require_once __DIR__ . '/abilities-api/class-wp-abilities-category-registry.php';
 }
+if ( ! class_exists( 'WP_Abilities_Query' ) ) {
+	require_once __DIR__ . '/abilities-api/class-wp-abilities-query.php';
+}
 
 // Ensure procedural functions are available, too.
 if ( ! function_exists( 'wp_register_ability' ) ) {

--- a/tests/unit/abilities-api/wpAbilitiesQuery.php
+++ b/tests/unit/abilities-api/wpAbilitiesQuery.php
@@ -1,0 +1,834 @@
+<?php declare( strict_types=1 );
+
+/**
+ * Tests for the abilities query functionality.
+ *
+ * @covers WP_Abilities_Query
+ *
+ * @group abilities-api
+ */
+class Tests_Abilities_API_WpAbilitiesQuery extends WP_UnitTestCase {
+
+	/**
+	 * Abilities registry instance.
+	 *
+	 * @var \WP_Abilities_Registry
+	 */
+	private $registry = null;
+
+	/**
+	 * Set up each test method.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->registry = WP_Abilities_Registry::get_instance();
+
+		// Register test categories.
+		add_action(
+			'abilities_api_categories_init',
+			static function () {
+				$categories = array( 'math', 'data-retrieval', 'communication', 'ecommerce' );
+				foreach ( $categories as $category_slug ) {
+					$registry = WP_Abilities_Category_Registry::get_instance();
+					if ( $registry->is_registered( $category_slug ) ) {
+						continue;
+					}
+
+					wp_register_ability_category(
+						$category_slug,
+						array(
+							'label'       => ucfirst( $category_slug ),
+							'description' => ucfirst( $category_slug ) . ' category.',
+						)
+					);
+				}
+			}
+		);
+
+		// Fire the hook to allow category registration.
+		do_action( 'abilities_api_categories_init' );
+
+		// Register test abilities with diverse properties.
+		$this->register_test_abilities();
+	}
+
+	/**
+	 * Tear down each test method.
+	 */
+	public function tear_down(): void {
+		// Clean up registered abilities.
+		$abilities = $this->registry->get_all_registered();
+		foreach ( $abilities as $ability ) {
+			$this->registry->unregister( $ability->get_name() );
+		}
+
+		// Clean up registered categories.
+		$category_registry = WP_Abilities_Category_Registry::get_instance();
+		$categories        = array( 'math', 'data-retrieval', 'communication', 'ecommerce' );
+		foreach ( $categories as $category_slug ) {
+			if ( ! $category_registry->is_registered( $category_slug ) ) {
+				continue;
+			}
+
+			wp_unregister_ability_category( $category_slug );
+		}
+
+		$this->registry = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Registers test abilities with various properties for filtering tests.
+	 */
+	private function register_test_abilities(): void {
+		// Math abilities - test namespace.
+		$this->registry->register(
+			'test/add-numbers',
+			array(
+				'label'               => 'Add Numbers',
+				'description'         => 'Adds two numbers together.',
+				'category'            => 'math',
+				'execute_callback'    => static function ( array $input ): int {
+					return $input['a'] + $input['b'];
+				},
+				'permission_callback' => '__return_true',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'a' => array( 'type' => 'number' ),
+						'b' => array( 'type' => 'number' ),
+					),
+				),
+				'output_schema'       => array( 'type' => 'number' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			)
+		);
+
+		$this->registry->register(
+			'test/multiply-numbers',
+			array(
+				'label'               => 'Multiply Numbers',
+				'description'         => 'Multiplies two numbers together.',
+				'category'            => 'math',
+				'execute_callback'    => static function ( array $input ): int {
+					return $input['a'] * $input['b'];
+				},
+				'permission_callback' => '__return_true',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'a' => array( 'type' => 'number' ),
+						'b' => array( 'type' => 'number' ),
+					),
+				),
+				'output_schema'       => array( 'type' => 'number' ),
+				'meta'                => array(
+					'show_in_rest' => false,
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			)
+		);
+
+		// Data retrieval abilities - example namespace.
+		$this->registry->register(
+			'example/get-user-data',
+			array(
+				'label'               => 'Get User Data',
+				'description'         => 'Retrieves user data from the database.',
+				'category'            => 'data-retrieval',
+				'execute_callback'    => static function () {
+					return array( 'user' => 'John Doe' );
+				},
+				'permission_callback' => '__return_true',
+				'input_schema'        => array( 'type' => 'object' ),
+				'output_schema'       => array( 'type' => 'object' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'custom_key'   => 'custom_value',
+				),
+			)
+		);
+
+		// Communication abilities - demo namespace.
+		$this->registry->register(
+			'demo/send-email',
+			array(
+				'label'               => 'Send Email',
+				'description'         => 'Sends an email to a recipient.',
+				'category'            => 'communication',
+				'execute_callback'    => static function (): bool {
+					return true;
+				},
+				'permission_callback' => '__return_true',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'to'      => array( 'type' => 'string' ),
+						'subject' => array( 'type' => 'string' ),
+						'message' => array( 'type' => 'string' ),
+					),
+				),
+				'output_schema'       => array( 'type' => 'boolean' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
+					),
+				),
+			)
+		);
+
+		// E-commerce abilities.
+		$this->registry->register(
+			'example/process-payment',
+			array(
+				'label'               => 'Process Payment',
+				'description'         => 'Processes a payment transaction.',
+				'category'            => 'ecommerce',
+				'execute_callback'    => static function () {
+					return array( 'success' => true );
+				},
+				'permission_callback' => '__return_true',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'amount' => array( 'type' => 'number' ),
+					),
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'meta'                => array(
+					'show_in_rest' => false,
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => false,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Test basic query instantiation.
+	 *
+	 * @covers WP_Abilities_Query::__construct
+	 */
+	public function test_query_instantiation() {
+		$query = new WP_Abilities_Query();
+		$this->assertInstanceOf( WP_Abilities_Query::class, $query );
+	}
+
+	/**
+	 * Test query with no arguments returns all abilities.
+	 *
+	 * @covers WP_Abilities_Query::get_abilities
+	 */
+	public function test_query_no_args_returns_all() {
+		$query     = new WP_Abilities_Query();
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 5, $abilities );
+	}
+
+	/**
+	 * Test wp_get_abilities() without arguments (backward compatibility).
+	 *
+	 * @covers wp_get_abilities
+	 */
+	public function test_wp_get_abilities_without_args() {
+		$abilities = wp_get_abilities();
+
+		$this->assertCount( 5, $abilities );
+		$this->assertArrayHasKey( 'test/add-numbers', $abilities );
+	}
+
+	/**
+	 * Test wp_get_abilities() with arguments uses query.
+	 *
+	 * @covers wp_get_abilities
+	 */
+	public function test_wp_get_abilities_with_args() {
+		$abilities = wp_get_abilities( array( 'category' => 'math' ) );
+
+		$this->assertCount( 2, $abilities );
+	}
+
+	/**
+	 * Test filter by category.
+	 *
+	 * @covers WP_Abilities_Query::apply_filters
+	 */
+	public function test_filter_by_category() {
+		$query     = new WP_Abilities_Query( array( 'category' => 'math' ) );
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 2, $abilities );
+		foreach ( $abilities as $ability ) {
+			$this->assertSame( 'math', $ability->get_category() );
+		}
+	}
+
+	/**
+	 * Test filter by multiple categories.
+	 *
+	 * @covers WP_Abilities_Query::apply_filters
+	 */
+	public function test_filter_by_multiple_categories() {
+		$query     = new WP_Abilities_Query( array( 'category' => array( 'math', 'communication' ) ) );
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 3, $abilities );
+		foreach ( $abilities as $ability ) {
+			$this->assertContains( $ability->get_category(), array( 'math', 'communication' ) );
+		}
+	}
+
+	/**
+	 * Test filter by namespace.
+	 *
+	 * @covers WP_Abilities_Query::apply_filters
+	 */
+	public function test_filter_by_namespace() {
+		$query     = new WP_Abilities_Query( array( 'namespace' => 'test' ) );
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 2, $abilities );
+		foreach ( $abilities as $ability ) {
+			$this->assertStringStartsWith( 'test/', $ability->get_name() );
+		}
+	}
+
+	/**
+	 * Test filter by multiple namespaces.
+	 *
+	 * @covers WP_Abilities_Query::apply_filters
+	 */
+	public function test_filter_by_multiple_namespaces() {
+		$query     = new WP_Abilities_Query( array( 'namespace' => array( 'test', 'example' ) ) );
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 4, $abilities );
+		foreach ( $abilities as $ability ) {
+			$name      = $ability->get_name();
+			$namespace = substr( $name, 0, strpos( $name, '/' ) );
+			$this->assertContains( $namespace, array( 'test', 'example' ) );
+		}
+	}
+
+	/**
+	 * Test filter by search term in name.
+	 *
+	 * @covers WP_Abilities_Query::apply_filters
+	 */
+	public function test_filter_by_search_in_name() {
+		$query     = new WP_Abilities_Query( array( 'search' => 'email' ) );
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 1, $abilities );
+		$ability = reset( $abilities );
+		$this->assertSame( 'demo/send-email', $ability->get_name() );
+	}
+
+	/**
+	 * Test filter by search term in label.
+	 *
+	 * @covers WP_Abilities_Query::apply_filters
+	 */
+	public function test_filter_by_search_in_label() {
+		$query     = new WP_Abilities_Query( array( 'search' => 'multiply' ) );
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 1, $abilities );
+		$ability = reset( $abilities );
+		$this->assertSame( 'test/multiply-numbers', $ability->get_name() );
+	}
+
+	/**
+	 * Test filter by search term in description.
+	 *
+	 * @covers WP_Abilities_Query::apply_filters
+	 */
+	public function test_filter_by_search_in_description() {
+		$query     = new WP_Abilities_Query( array( 'search' => 'payment' ) );
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 1, $abilities );
+		$ability = reset( $abilities );
+		$this->assertSame( 'example/process-payment', $ability->get_name() );
+	}
+
+	/**
+	 * Test filter by show_in_rest using structured array.
+	 *
+	 * @covers WP_Abilities_Query::apply_filters
+	 * @covers WP_Abilities_Query::matches_meta_filters
+	 */
+	public function test_filter_by_show_in_rest_structured() {
+		$query = new WP_Abilities_Query(
+			array(
+				'meta' => array(
+					'show_in_rest' => true,
+				),
+			)
+		);
+
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 3, $abilities );
+		foreach ( $abilities as $ability ) {
+			$this->assertTrue( $ability->get_meta_item( 'show_in_rest' ) );
+		}
+	}
+
+
+	/**
+	 * Test filter by readonly annotation using structured array.
+	 *
+	 * @covers WP_Abilities_Query::apply_filters
+	 * @covers WP_Abilities_Query::matches_meta_filters
+	 */
+	public function test_filter_by_readonly_structured() {
+		$query = new WP_Abilities_Query(
+			array(
+				'meta' => array(
+					'annotations' => array(
+						'readonly' => true,
+					),
+				),
+			)
+		);
+
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 3, $abilities );
+		foreach ( $abilities as $ability ) {
+			$meta = $ability->get_meta();
+			$this->assertTrue( $meta['annotations']['readonly'] );
+		}
+	}
+
+
+	/**
+	 * Test filter by destructive annotation.
+	 *
+	 * @covers WP_Abilities_Query::apply_filters
+	 * @covers WP_Abilities_Query::matches_meta_filters
+	 */
+	public function test_filter_by_destructive() {
+		$query = new WP_Abilities_Query(
+			array(
+				'meta' => array(
+					'annotations' => array(
+						'destructive' => true,
+					),
+				),
+			)
+		);
+
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 1, $abilities );
+		$ability = reset( $abilities );
+		$this->assertSame( 'example/process-payment', $ability->get_name() );
+	}
+
+	/**
+	 * Test filter by idempotent annotation.
+	 *
+	 * @covers WP_Abilities_Query::apply_filters
+	 * @covers WP_Abilities_Query::matches_meta_filters
+	 */
+	public function test_filter_by_idempotent() {
+		$query = new WP_Abilities_Query(
+			array(
+				'meta' => array(
+					'annotations' => array(
+						'idempotent' => true,
+					),
+				),
+			)
+		);
+
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 3, $abilities );
+	}
+
+	/**
+	 * Test filter by custom meta key.
+	 *
+	 * @covers WP_Abilities_Query::apply_filters
+	 * @covers WP_Abilities_Query::matches_meta_filters
+	 */
+	public function test_filter_by_custom_meta() {
+		$query = new WP_Abilities_Query(
+			array(
+				'meta' => array(
+					'custom_key' => 'custom_value',
+				),
+			)
+		);
+
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 1, $abilities );
+		$ability = reset( $abilities );
+		$this->assertSame( 'example/get-user-data', $ability->get_name() );
+	}
+
+	/**
+	 * Test meta filters with AND logic (all conditions must match).
+	 *
+	 * @covers WP_Abilities_Query::apply_filters
+	 * @covers WP_Abilities_Query::matches_meta
+	 */
+	public function test_meta_filters_and_logic() {
+		$query = new WP_Abilities_Query(
+			array(
+				'meta' => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly' => true,
+					),
+				),
+			)
+		);
+
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 2, $abilities );
+		foreach ( $abilities as $ability ) {
+			$this->assertTrue( $ability->get_meta_item( 'show_in_rest' ) );
+			$meta = $ability->get_meta();
+			$this->assertTrue( $meta['annotations']['readonly'] );
+		}
+	}
+
+	/**
+	 * Test multiple filters combined.
+	 *
+	 * @covers WP_Abilities_Query::get_abilities
+	 */
+	public function test_multiple_filters_combined() {
+		$query = new WP_Abilities_Query(
+			array(
+				'category' => 'math',
+				'meta'     => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly' => true,
+					),
+				),
+			)
+		);
+
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 1, $abilities );
+		$ability = reset( $abilities );
+		$this->assertSame( 'test/add-numbers', $ability->get_name() );
+	}
+
+	/**
+	 * Test order by name ascending (default).
+	 *
+	 * @covers WP_Abilities_Query::apply_ordering
+	 */
+	public function test_order_by_name_asc() {
+		$query     = new WP_Abilities_Query( array( 'orderby' => 'name' ) );
+		$abilities = $query->get_abilities();
+
+		$names = array_map(
+			static function ( $ability ) {
+				return $ability->get_name();
+			},
+			$abilities
+		);
+
+		$expected = array(
+			'demo/send-email',
+			'example/get-user-data',
+			'example/process-payment',
+			'test/add-numbers',
+			'test/multiply-numbers',
+		);
+
+		$this->assertSame( $expected, $names );
+	}
+
+	/**
+	 * Test order by name descending.
+	 *
+	 * @covers WP_Abilities_Query::apply_ordering
+	 */
+	public function test_order_by_name_desc() {
+		$query = new WP_Abilities_Query(
+			array(
+				'orderby' => 'name',
+				'order'   => 'DESC',
+			)
+		);
+
+		$abilities = $query->get_abilities();
+
+		$names = array_map(
+			static function ( $ability ) {
+				return $ability->get_name();
+			},
+			$abilities
+		);
+
+		$expected = array(
+			'test/multiply-numbers',
+			'test/add-numbers',
+			'example/process-payment',
+			'example/get-user-data',
+			'demo/send-email',
+		);
+
+		$this->assertSame( $expected, $names );
+	}
+
+	/**
+	 * Test order by label.
+	 *
+	 * @covers WP_Abilities_Query::apply_ordering
+	 */
+	public function test_order_by_label() {
+		$query = new WP_Abilities_Query(
+			array(
+				'orderby' => 'label',
+				'order'   => 'ASC',
+			)
+		);
+
+		$abilities = $query->get_abilities();
+
+		$labels = array_map(
+			static function ( $ability ) {
+				return $ability->get_label();
+			},
+			$abilities
+		);
+
+		$expected = array(
+			'Add Numbers',
+			'Get User Data',
+			'Multiply Numbers',
+			'Process Payment',
+			'Send Email',
+		);
+
+		$this->assertSame( $expected, $labels );
+	}
+
+	/**
+	 * Test order by category.
+	 *
+	 * @covers WP_Abilities_Query::apply_ordering
+	 */
+	public function test_order_by_category() {
+		$query = new WP_Abilities_Query(
+			array(
+				'orderby' => 'category',
+				'order'   => 'ASC',
+			)
+		);
+
+		$abilities = $query->get_abilities();
+
+		$categories = array_map(
+			static function ( $ability ) {
+				return $ability->get_category();
+			},
+			$abilities
+		);
+
+		$expected = array(
+			'communication',
+			'data-retrieval',
+			'ecommerce',
+			'math',
+			'math',
+		);
+
+		$this->assertSame( $expected, $categories );
+	}
+
+	/**
+	 * Test pagination with limit.
+	 *
+	 * @covers WP_Abilities_Query::apply_pagination
+	 */
+	public function test_pagination_limit() {
+		$query     = new WP_Abilities_Query( array( 'limit' => 2 ) );
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 2, $abilities );
+	}
+
+	/**
+	 * Test pagination with offset.
+	 *
+	 * @covers WP_Abilities_Query::apply_pagination
+	 */
+	public function test_pagination_offset() {
+		$query = new WP_Abilities_Query(
+			array(
+				'orderby' => 'name',
+				'offset'  => 2,
+			)
+		);
+
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 3, $abilities );
+		$first = reset( $abilities );
+		$this->assertSame( 'example/process-payment', $first->get_name() );
+	}
+
+	/**
+	 * Test pagination with both limit and offset.
+	 *
+	 * @covers WP_Abilities_Query::apply_pagination
+	 */
+	public function test_pagination_limit_and_offset() {
+		$query = new WP_Abilities_Query(
+			array(
+				'orderby' => 'name',
+				'limit'   => 2,
+				'offset'  => 1,
+			)
+		);
+
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 2, $abilities );
+
+		$names = array_map(
+			static function ( $ability ) {
+				return $ability->get_name();
+			},
+			$abilities
+		);
+
+		$expected = array(
+			'example/get-user-data',
+			'example/process-payment',
+		);
+
+		$this->assertSame( $expected, $names );
+	}
+
+	/**
+	 * Test query returns empty array when no matches.
+	 *
+	 * @covers WP_Abilities_Query::get_abilities
+	 */
+	public function test_no_matches_returns_empty_array() {
+		$query     = new WP_Abilities_Query( array( 'category' => 'nonexistent' ) );
+		$abilities = $query->get_abilities();
+
+		$this->assertIsArray( $abilities );
+		$this->assertEmpty( $abilities );
+	}
+
+	/**
+	 * Test query::get() method returns all query vars.
+	 *
+	 * @covers WP_Abilities_Query::get
+	 */
+	public function test_get_query_vars() {
+		$query      = new WP_Abilities_Query( array( 'category' => 'math' ) );
+		$query_vars = $query->get();
+
+		$this->assertIsArray( $query_vars );
+		$this->assertSame( 'math', $query_vars['category'] );
+	}
+
+	/**
+	 * Test query::get() method with specific key.
+	 *
+	 * @covers WP_Abilities_Query::get
+	 */
+	public function test_get_specific_query_var() {
+		$query    = new WP_Abilities_Query( array( 'category' => 'math' ) );
+		$category = $query->get( 'category' );
+
+		$this->assertSame( 'math', $category );
+	}
+
+	/**
+	 * Test invalid orderby defaults to empty string (no ordering).
+	 *
+	 * @covers WP_Abilities_Query::parse_query
+	 */
+	public function test_invalid_orderby_defaults_to_empty() {
+		$query   = new WP_Abilities_Query( array( 'orderby' => 'invalid' ) );
+		$orderby = $query->get( 'orderby' );
+
+		$this->assertSame( '', $orderby );
+	}
+
+	/**
+	 * Test invalid order defaults to 'ASC'.
+	 *
+	 * @covers WP_Abilities_Query::parse_query
+	 */
+	public function test_invalid_order_defaults_to_asc() {
+		$query = new WP_Abilities_Query( array( 'order' => 'invalid' ) );
+		$order = $query->get( 'order' );
+
+		$this->assertSame( 'ASC', $order );
+	}
+
+
+	/**
+	 * Test query results are cached.
+	 *
+	 * @covers WP_Abilities_Query::get_abilities
+	 */
+	public function test_query_results_are_cached() {
+		$query = new WP_Abilities_Query( array( 'category' => 'math' ) );
+
+		$first_call  = $query->get_abilities();
+		$second_call = $query->get_abilities();
+
+		// Should return same instance (cached).
+		$this->assertSame( $first_call, $second_call );
+	}
+
+	/**
+	 * Test case-insensitive search.
+	 *
+	 * @covers WP_Abilities_Query::apply_filters
+	 */
+	public function test_case_insensitive_search() {
+		$query     = new WP_Abilities_Query( array( 'search' => 'EMAIL' ) );
+		$abilities = $query->get_abilities();
+
+		$this->assertCount( 1, $abilities );
+		$ability = reset( $abilities );
+		$this->assertSame( 'demo/send-email', $ability->get_name() );
+	}
+}


### PR DESCRIPTION
 ## Summary

Closes https://github.com/WordPress/abilities-api/issues/38.

Adds querying and filtering capabilities to the Abilities API, allowing developers to efficiently find and retrieve specific abilities from potentially thousands of registered abilities.

This PR introduces the WP_Abilities_Query class and extends wp_get_abilities() to accept filtering arguments, enabling server-side filtering by category, namespace, meta properties, search terms, and more.

 ## Changes

**New Features**

  - New `WP_Abilities_Query` class - WordPress-standard query interface for filtering abilities
  - Enhanced `wp_get_abilities()` function - Now accepts optional `$args` parameter for filtering
  - Multiple filter types:
    - category - Filter by category slug (single or array)
    - namespace - Filter by namespace (single or array)
    - search - Search in name, label, and description
    - meta - Filter by meta properties (show_in_rest, annotations, custom meta)
    - orderby - Sort by name, label, or category
    - order - Sort direction (ASC/DESC)
    - limit/offset - Pagination support

 **Implementation Details**

  - All filters use AND logic between different filter types
  - Multiple values in category or namespace use OR logic
  - Meta filters support nested arrays with AND logic
  - Single-pass filtering for optimal performance


## Documentation

  - New comprehensive documentation in `docs/8.querying-filtering-abilities.md`
  - Updated `docs/4.using-abilities.md` with filtering examples
  - Includes a quick reference table and detailed examples
  
## Backward Compatibility

Fully backward compatible - existing code calling `wp_get_abilities() `without arguments continues to work unchanged.