### PR TITLE
Update version to 0.3.0 in preparation to Composer package release

### DIFF
--- a/abilities-api.php
+++ b/abilities-api.php
@@ -12,7 +12,7 @@
  * Plugin URI:        https://github.com/WordPress/abilities-api
  * Description:       Provides a framework for registering and executing AI abilities in WordPress.
  * Requires at least: 6.8
- * Version:           0.2.0
+ * Version:           0.3.0
  * Requires PHP:      7.2
  * Author:            WordPress.org Contributors
  * Author URI:        https://github.com/WordPress/abilities-api/graphs/contributors

--- a/includes/abilities-api.php
+++ b/includes/abilities-api.php
@@ -107,7 +107,7 @@ function wp_get_abilities(): array {
 /**
  * Registers a new ability category.
  *
- * @since n.e.x.t
+ * @since 0.3.0
  *
  * @see WP_Abilities_Category_Registry::register()
  *
@@ -131,7 +131,7 @@ function wp_register_ability_category( string $slug, array $args ): ?WP_Ability_
 /**
  * Unregisters an ability category.
  *
- * @since n.e.x.t
+ * @since 0.3.0
  *
  * @see WP_Abilities_Category_Registry::unregister()
  *
@@ -145,7 +145,7 @@ function wp_unregister_ability_category( string $slug ): ?WP_Ability_Category {
 /**
  * Retrieves a registered ability category.
  *
- * @since n.e.x.t
+ * @since 0.3.0
  *
  * @see WP_Abilities_Category_Registry::get_registered()
  *
@@ -159,7 +159,7 @@ function wp_get_ability_category( string $slug ): ?WP_Ability_Category {
 /**
  * Retrieves all registered ability categories.
  *
- * @since n.e.x.t
+ * @since 0.3.0
  *
  * @see WP_Abilities_Category_Registry::get_all_registered()
  *

--- a/includes/abilities-api/class-wp-abilities-category-registry.php
+++ b/includes/abilities-api/class-wp-abilities-category-registry.php
@@ -6,7 +6,7 @@
  *
  * @package WordPress
  * @subpackage Abilities API
- * @since n.e.x.t
+ * @since 0.3.0
  */
 
 declare( strict_types = 1 );
@@ -14,14 +14,14 @@ declare( strict_types = 1 );
 /**
  * Manages the registration and lookup of ability categories.
  *
- * @since n.e.x.t
+ * @since 0.3.0
  * @access private
  */
 final class WP_Abilities_Category_Registry {
 	/**
 	 * The singleton instance of the registry.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 * @var ?self
 	 */
 	private static $instance = null;
@@ -29,7 +29,7 @@ final class WP_Abilities_Category_Registry {
 	/**
 	 * Holds the registered categories.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 * @var \WP_Ability_Category[]
 	 */
 	private $registered_categories = array();
@@ -39,7 +39,7 @@ final class WP_Abilities_Category_Registry {
 	 *
 	 * Do not use this method directly. Instead, use the `wp_register_ability_category()` function.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @see wp_register_ability_category()
 	 *
@@ -66,7 +66,7 @@ final class WP_Abilities_Category_Registry {
 					'<code>abilities_api_categories_init</code>',
 					'<code>' . esc_html( $slug ) . '</code>'
 				),
-				'n.e.x.t'
+				'0.3.0'
 			);
 			return null;
 		}
@@ -76,7 +76,7 @@ final class WP_Abilities_Category_Registry {
 				__METHOD__,
 				/* translators: %s: Category slug. */
 				esc_html( sprintf( __( 'Category "%s" is already registered.' ), $slug ) ),
-				'n.e.x.t'
+				'0.3.0'
 			);
 			return null;
 		}
@@ -85,7 +85,7 @@ final class WP_Abilities_Category_Registry {
 			_doing_it_wrong(
 				__METHOD__,
 				esc_html__( 'Category slug must contain only lowercase alphanumeric characters and dashes.' ),
-				'n.e.x.t'
+				'0.3.0'
 			);
 			return null;
 		}
@@ -93,7 +93,7 @@ final class WP_Abilities_Category_Registry {
 		/**
 		 * Filters the category arguments before they are validated and used to instantiate the category.
 		 *
-		 * @since n.e.x.t
+		 * @since 0.3.0
 		 *
 		 * @param array<string,mixed> $args The arguments used to instantiate the category.
 		 * @param string              $slug The slug of the category.
@@ -107,7 +107,7 @@ final class WP_Abilities_Category_Registry {
 			_doing_it_wrong(
 				__METHOD__,
 				esc_html( $e->getMessage() ),
-				'n.e.x.t'
+				'0.3.0'
 			);
 			return null;
 		}
@@ -121,7 +121,7 @@ final class WP_Abilities_Category_Registry {
 	 *
 	 * Do not use this method directly. Instead, use the `wp_unregister_ability_category()` function.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @see wp_unregister_ability_category()
 	 *
@@ -134,7 +134,7 @@ final class WP_Abilities_Category_Registry {
 				__METHOD__,
 				/* translators: %s: Ability category slug. */
 				sprintf( esc_html__( 'Ability category "%s" not found.' ), esc_attr( $slug ) ),
-				'n.e.x.t'
+				'0.3.0'
 			);
 			return null;
 		}
@@ -150,7 +150,7 @@ final class WP_Abilities_Category_Registry {
 	 *
 	 * Do not use this method directly. Instead, use the `wp_get_ability_categories()` function.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @see wp_get_ability_categories()
 	 *
@@ -163,7 +163,7 @@ final class WP_Abilities_Category_Registry {
 	/**
 	 * Checks if a category is registered.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @param string $slug The slug of the category.
 	 * @return bool True if the category is registered, false otherwise.
@@ -177,7 +177,7 @@ final class WP_Abilities_Category_Registry {
 	 *
 	 * Do not use this method directly. Instead, use the `wp_get_ability_category()` function.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @see wp_get_ability_category()
 	 *
@@ -190,7 +190,7 @@ final class WP_Abilities_Category_Registry {
 				__METHOD__,
 				/* translators: %s: Ability category slug. */
 				sprintf( esc_html__( 'Ability category "%s" not found.' ), esc_attr( $slug ) ),
-				'n.e.x.t'
+				'0.3.0'
 			);
 			return null;
 		}
@@ -202,7 +202,7 @@ final class WP_Abilities_Category_Registry {
 	 *
 	 * The instance will be created if it does not exist yet.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @return \WP_Abilities_Category_Registry The main registry instance.
 	 */
@@ -215,7 +215,7 @@ final class WP_Abilities_Category_Registry {
 			 *
 			 * Categories should be registered on this action to ensure they're available when needed.
 			 *
-			 * @since n.e.x.t
+			 * @since 0.3.0
 			 *
 			 * @param \WP_Abilities_Category_Registry $instance Categories registry object.
 			 */
@@ -228,7 +228,7 @@ final class WP_Abilities_Category_Registry {
 	/**
 	 * Wakeup magic method.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 * @throws \LogicException If the registry is unserialized. This is a security hardening measure to prevent unserialization of the registry.
 	 */
 	public function __wakeup(): void {
@@ -238,7 +238,7 @@ final class WP_Abilities_Category_Registry {
 	/**
 	 * Serialization magic method.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 * @throws \LogicException If the registry is serialized. This is a security hardening measure to prevent serialization of the registry.
 	 */
 	public function __sleep(): array {

--- a/includes/abilities-api/class-wp-abilities-registry.php
+++ b/includes/abilities-api/class-wp-abilities-registry.php
@@ -111,7 +111,7 @@ final class WP_Abilities_Registry {
 						esc_attr( $args['category'] ),
 						esc_attr( $name )
 					),
-					'n.e.x.t'
+					'0.3.0'
 				);
 				return null;
 			}

--- a/includes/abilities-api/class-wp-ability-category.php
+++ b/includes/abilities-api/class-wp-ability-category.php
@@ -6,7 +6,7 @@
  *
  * @package WordPress
  * @subpackage Abilities API
- * @since n.e.x.t
+ * @since 0.3.0
  */
 
 declare( strict_types = 1 );
@@ -14,7 +14,7 @@ declare( strict_types = 1 );
 /**
  * Encapsulates the properties and methods related to a specific ability category.
  *
- * @since n.e.x.t
+ * @since 0.3.0
  *
  * @see WP_Abilities_Category_Registry
  */
@@ -23,7 +23,7 @@ final class WP_Ability_Category {
 	/**
 	 * The unique slug for the category.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 * @var string
 	 */
 	protected $slug;
@@ -31,7 +31,7 @@ final class WP_Ability_Category {
 	/**
 	 * The human-readable category label.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 * @var string
 	 */
 	protected $label;
@@ -39,7 +39,7 @@ final class WP_Ability_Category {
 	/**
 	 * The detailed category description.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 * @var string
 	 */
 	protected $description;
@@ -47,7 +47,7 @@ final class WP_Ability_Category {
 	/**
 	 * The optional category metadata.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 * @var array<string,mixed>
 	 */
 	protected $meta = array();
@@ -59,7 +59,7 @@ final class WP_Ability_Category {
 	 *
 	 * @access private
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @see wp_register_ability_category()
 	 *
@@ -88,7 +88,7 @@ final class WP_Ability_Category {
 						'<code>' . esc_html( $this->slug ) . '</code>',
 						'<code>' . esc_html( self::class ) . '</code>'
 					),
-					'n.e.x.t'
+					'0.3.0'
 				);
 				continue;
 			}
@@ -100,7 +100,7 @@ final class WP_Ability_Category {
 	/**
 	 * Prepares and validates the properties used to instantiate the category.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @param array<string,mixed> $args An associative array of arguments used to instantiate the class.
 	 * @return array<string,mixed> The validated and prepared properties.
@@ -140,7 +140,7 @@ final class WP_Ability_Category {
 	/**
 	 * Retrieves the slug of the category.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @return string The category slug.
 	 */
@@ -151,7 +151,7 @@ final class WP_Ability_Category {
 	/**
 	 * Retrieves the human-readable label for the category.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @return string The human-readable category label.
 	 */
@@ -162,7 +162,7 @@ final class WP_Ability_Category {
 	/**
 	 * Retrieves the detailed description for the category.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @return string The detailed description for the category.
 	 */
@@ -173,7 +173,7 @@ final class WP_Ability_Category {
 	/**
 	 * Retrieves the metadata for the category.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @return array<string,mixed> The metadata for the category.
 	 */
@@ -184,7 +184,7 @@ final class WP_Ability_Category {
 	/**
 	 * Wakeup magic method.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 * @throws \LogicException If the category is unserialized. This is a security hardening measure to prevent unserialization of the category.
 	 */
 	public function __wakeup(): void {
@@ -194,7 +194,7 @@ final class WP_Ability_Category {
 	/**
 	 * Serialization magic method.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 * @throws \LogicException If the category is serialized. This is a security hardening measure to prevent serialization of the category.
 	 */
 	public function __sleep(): array {

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -23,7 +23,7 @@ class WP_Ability {
 	/**
 	 * The default value for the `show_in_rest` meta.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 * @var bool
 	 */
 	protected const DEFAULT_SHOW_IN_REST = false;
@@ -32,7 +32,7 @@ class WP_Ability {
 	 * The default ability annotations.
 	 * They are not guaranteed to provide a faithful description of ability behavior.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 * @var array<string,(bool|string)>
 	 */
 	protected static $default_annotations = array(
@@ -120,7 +120,7 @@ class WP_Ability {
 	/**
 	 * The ability category (required).
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 * @var string
 	 */
 	protected $category;
@@ -345,7 +345,7 @@ class WP_Ability {
 	/**
 	 * Retrieves the category for the ability.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @return string The category for the ability.
 	 */
@@ -356,7 +356,7 @@ class WP_Ability {
 	/**
 	 * Retrieves a specific metadata item for the ability.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @param string $key           The metadata key to retrieve.
 	 * @param mixed  $default_value Optional. The default value to return if the metadata item is not found. Default `null`.
@@ -410,7 +410,7 @@ class WP_Ability {
 	/**
 	 * Invokes a callable, ensuring the input is passed through only if the input schema is defined.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @param callable $callback The callable to invoke.
 	 * @param mixed    $input    Optional. The input data for the ability. Default `null`.

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Version of the plugin.
 if ( ! defined( 'WP_ABILITIES_API_VERSION' ) ) {
-	define( 'WP_ABILITIES_API_VERSION', '0.2.0' );
+	define( 'WP_ABILITIES_API_VERSION', '0.3.0' );
 }
 
 // Load core classes if they are not already defined (for non-Composer installs or direct includes).

--- a/tests/unit/abilities-api/wpAbility.php
+++ b/tests/unit/abilities-api/wpAbility.php
@@ -62,7 +62,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	}
 
 	/**
-   * Tear down after each test.
+	 * Tear down after each test.
 	 */
 	public function tear_down(): void {
 		// Clean up registered categories.
@@ -74,7 +74,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
-	 /*
+	/*
 	 * Tests that getting non-existing metadata item returns default value.
 	 */
 	public function test_meta_get_non_existing_item_returns_default() {
@@ -111,7 +111,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 				array(
 					'instructions' => '',
 					'idempotent'   => false,
-				),
+				)
 			),
 			$ability->get_meta_item( 'annotations' )
 		);
@@ -196,7 +196,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	 * Tests that `show_in_rest` metadata can be set to true.
 	 */
 	public function test_meta_show_in_rest_can_be_set_to_true() {
-		$args = array_merge(
+		$args    = array_merge(
 			self::$test_ability_properties,
 			array(
 				'meta' => array(
@@ -216,7 +216,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	 * Tests that `show_in_rest` can be set to false.
 	 */
 	public function test_show_in_rest_can_be_set_to_false() {
-		$args = array_merge(
+		$args    = array_merge(
 			self::$test_ability_properties,
 			array(
 				'meta' => array(
@@ -407,7 +407,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	 */
 	public function data_execute_callback() {
 		return array(
-			'function name string'      => array(
+			'function name string'       => array(
 				'strlen',
 			),
 			'closure'                    => array(
@@ -432,7 +432,7 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_execute_callback
 	 */
-	public function test_execute_with_different_callbacks( $execute_callback) {
+	public function test_execute_with_different_callbacks( $execute_callback ) {
 		$args = array_merge(
 			self::$test_ability_properties,
 			array(

--- a/tests/unit/abilities-api/wpRegisterAbility.php
+++ b/tests/unit/abilities-api/wpRegisterAbility.php
@@ -156,14 +156,14 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 
 		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
 
-		$expected_annotations  = array_merge(
+		$expected_annotations = array_merge(
 			self::$test_ability_args['meta']['annotations'],
 			array(
 				'instructions' => '',
 				'idempotent'   => false,
-			),
+			)
 		);
-		$expected_meta         = array_merge(
+		$expected_meta        = array_merge(
 			self::$test_ability_args['meta'],
 			array(
 				'annotations'  => $expected_annotations,


### PR DESCRIPTION
Similar process as with https://github.com/WordPress/abilities-api/pull/90.

This PR prepares the branch to release `v0.3.0` based on the work accomplished in [pre WP 6.9 milestone](https://github.com/WordPress/abilities-api/milestone/5):

- Replaces `@since n.e.x.t` with `@since 0.3.0`
- Bumps version from `0.2.0` to `0.3.0`
- Includes coding style fixes necessary to pass CI check in WordPress core.

The same version was tested against WP core with https://github.com/WordPress/wordpress-develop/pull/9410 and all CI checks passed with the changes applied.