### PR TITLE
Switch to Classmap for bootstrap autoloading

### DIFF
--- a/abilities-api.php
+++ b/abilities-api.php
@@ -26,5 +26,9 @@
  */
 define( 'WP_ABILITIES_API_DIR', plugin_dir_path( __FILE__ ) );
 
+// Load Composer autoloader if not already loaded (for standalone plugin usage).
+if ( file_exists( WP_ABILITIES_API_DIR . 'vendor/autoload.php' ) ) {
+	require_once WP_ABILITIES_API_DIR . 'vendor/autoload.php';
+}
 
 require_once WP_ABILITIES_API_DIR . 'includes/bootstrap.php';

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,11 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"autoload": {
+		"classmap": [
+			"includes/abilities-api/",
+			"includes/rest-api/",
+			"includes/assets/"
+		],
 		"files": [
 			"includes/bootstrap.php"
 		]

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -22,42 +22,16 @@ if ( ! defined( 'WP_ABILITIES_API_VERSION' ) ) {
 	define( 'WP_ABILITIES_API_VERSION', '0.3.0' );
 }
 
-// Load core classes if they are not already defined (for non-Composer installs or direct includes).
-if ( ! class_exists( 'WP_Ability' ) ) {
-	require_once __DIR__ . '/abilities-api/class-wp-ability.php';
-}
-if ( ! class_exists( 'WP_Abilities_Registry' ) ) {
-	require_once __DIR__ . '/abilities-api/class-wp-abilities-registry.php';
-}
-if ( ! class_exists( 'WP_Ability_Category' ) ) {
-	require_once __DIR__ . '/abilities-api/class-wp-ability-category.php';
-}
-if ( ! class_exists( 'WP_Abilities_Category_Registry' ) ) {
-	require_once __DIR__ . '/abilities-api/class-wp-abilities-category-registry.php';
-}
-
-// Ensure procedural functions are available, too.
+// Ensure procedural functions are available.
+// Classes are autoloaded via Composer's classmap.
 if ( ! function_exists( 'wp_register_ability' ) ) {
 	require_once __DIR__ . '/abilities-api.php';
 }
 
-// Load REST API init class for plugin bootstrap.
-if ( ! class_exists( 'WP_REST_Abilities_Init' ) ) {
-	require_once __DIR__ . '/rest-api/class-wp-rest-abilities-init.php';
-
-	// Initialize REST API routes when WordPress is available.
-	if ( function_exists( 'add_action' ) ) {
-		add_action( 'rest_api_init', array( 'WP_REST_Abilities_Init', 'register_routes' ) );
-	}
-}
-
-// Load assets init class for plugin bootstrap.
-if ( ! class_exists( 'WP_Abilities_Assets_Init' ) ) {
-	require_once __DIR__ . '/assets/class-wp-abilities-assets-init.php';
-
-	// Initialize client assets when WordPress is available.
-	if ( function_exists( 'add_action' ) ) {
-		add_action( 'init', array( 'WP_Abilities_Assets_Init', 'register_assets' ) );
-		add_action( 'admin_enqueue_scripts', array( 'WP_Abilities_Assets_Init', 'admin_enqueue_scripts' ) );
-	}
+// Initialize REST API routes when WordPress is available.
+// Classes are autoloaded by Composer when the hooks fire.
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'rest_api_init', array( 'WP_REST_Abilities_Init', 'register_routes' ) );
+	add_action( 'init', array( 'WP_Abilities_Assets_Init', 'register_assets' ) );
+	add_action( 'admin_enqueue_scripts', array( 'WP_Abilities_Assets_Init', 'admin_enqueue_scripts' ) );
 }


### PR DESCRIPTION
It was pointed out that using `require_once` in `boostrap.php` was causing this plugin to not work properly with the Jetpack Autoloader, which relies on the classmap to control loading the latest version when both are present (0.2.0 and 0.3.0, for instance).

This PR addresses this by switching to using a Classmap for the autoloading of classes. I'm not terribly familiar with the nuances of how Jetpack autloader works, so I _think_ I got this right. I added a check for using the built-in autoloader as well, so this can still work standalone. I'm hoping that doesn't cause issues with the Jetpack autoloader.