### PR TITLE
Update: Json schema version 

### DIFF
--- a/packages/client/src/validation.ts
+++ b/packages/client/src/validation.ts
@@ -7,7 +7,7 @@
  *
  * @see https://developer.wordpress.org/rest-api/extending-the-rest-api/schema/#json-schema-basics
  */
-import Ajv from 'ajv-draft-04';
+import Ajv from 'ajv/dist/2020';
 import addFormats from 'ajv-formats';
 import type { ValidationError } from './types';
 
@@ -169,7 +169,7 @@ export function validateValueFromSchema(
 
 	try {
 		const validate = ajv.compile( args );
-		const valid = validate( value );
+		const valid = validate( value || {} );
 
 		if ( valid ) {
 			return true;


### PR DESCRIPTION
We are currently using draft-04 of json schema on the validator, but the schemas we are using required at least the 2020 version because of having examples and defaults.

## Testing
Currently the ajv validation only happens for the output of client side abiltiies not the server ones so this issue is hidden but it will be exposed when hybrid abilities are implemented.

Paste the following code on the browser console:
```
const envInfoAbility = await wp.abilities.getAbility(
	'core/get-environment-info'
);
const envInfoResult = await wp.abilities.executeAbility(
	'core/get-environment-info'
);
await wp.abilities.registerAbility( {
	...envInfoAbility,
	name: 'core/get-environment-info-client',
	callback: () => envInfoResult,
} );
await wp.abilities.executeAbility( 'core/get-environment-info-client' );
```
It registers a core/get-environment-info-client client ability exactly the same as the server one.
Verify things work well.
Paste the same code on trunk and verify there is this error and the ability does not works:
```
Schema compilation error: Error: strict mode: unknown keyword: "examples"
    at checkStrictMode (util.js:174:1)
    at checkUnknownRules (util.js:32:1)
    at alwaysValidSchema (util.js:19:1)
    at properties.js:23:1
    at Array.filter (<anonymous>)
    at Object.code (properties.js:23:1)
    at keywordCode (index.js:464:1)
    at index.js:222:1
    at CodeGen.code (index.js:439:1)
    at CodeGen.block (index.js:568:1)
```

