### PR TITLE
Fix: Input Validation handle top level default.

### DIFF
--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -324,7 +324,7 @@ async function executeServerAbility(
  */
 export async function executeAbility(
 	name: string,
-	input: AbilityInput
+	input?: AbilityInput
 ): Promise< AbilityOutput > {
 	const ability = await getAbility( name );
 	if ( ! ability ) {

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -324,7 +324,7 @@ async function executeServerAbility(
  */
 export async function executeAbility(
 	name: string,
-	input: AbilityInput = null
+	input: AbilityInput
 ): Promise< AbilityOutput > {
 	const ability = await getAbility( name );
 	if ( ! ability ) {

--- a/packages/client/src/validation.ts
+++ b/packages/client/src/validation.ts
@@ -170,7 +170,11 @@ export function validateValueFromSchema(
 	try {
 		const { default: defaultValue, ...schemaWithoutDefault } = args;
 		const validate = ajv.compile( schemaWithoutDefault );
-		const valid = validate( value || defaultValue || {} );
+		let valueToValidate = value;
+		if ( valueToValidate === undefined && defaultValue !== undefined ) {
+			valueToValidate = defaultValue;
+		}
+		const valid = validate( valueToValidate );
 
 		if ( valid ) {
 			return true;

--- a/packages/client/src/validation.ts
+++ b/packages/client/src/validation.ts
@@ -170,11 +170,7 @@ export function validateValueFromSchema(
 	try {
 		const { default: defaultValue, ...schemaWithoutDefault } = args;
 		const validate = ajv.compile( schemaWithoutDefault );
-		let valueToValidate = value;
-		if ( valueToValidate === undefined && defaultValue !== undefined ) {
-			valueToValidate = defaultValue;
-		}
-		const valid = validate( valueToValidate );
+		const valid = validate( value === undefined ? defaultValue || {} : value );
 
 		if ( valid ) {
 			return true;

--- a/packages/client/src/validation.ts
+++ b/packages/client/src/validation.ts
@@ -170,7 +170,7 @@ export function validateValueFromSchema(
 	try {
 		const { default: defaultValue, ...schemaWithoutDefault } = args;
 		const validate = ajv.compile( schemaWithoutDefault );
-		const valid = validate( value === undefined ? defaultValue || {} : value );
+		const valid = validate( value === undefined ? defaultValue : value );
 
 		if ( valid ) {
 			return true;

--- a/packages/client/src/validation.ts
+++ b/packages/client/src/validation.ts
@@ -168,8 +168,9 @@ export function validateValueFromSchema(
 	}
 
 	try {
-		const validate = ajv.compile( args );
-		const valid = validate( value );
+		const { default: defaultValue, ...schemaWithoutDefault } = args;
+		const validate = ajv.compile( schemaWithoutDefault );
+		const valid = validate( value || defaultValue || {} );
 
 		if ( valid ) {
 			return true;


### PR DESCRIPTION
Apparently draft-04 of JSON schema allows the top level default, that we are using, but ajv validator errors if a top level default is used, it also error if null or undefined is passed as input.

This PR fixes the issue, we remove the default from the compile schema and use it as the input when it is defined.

## Testing
On core switch to PR (which has required core changes to be draft-04 complient and work correctly, like removing examples and return JSON containing a default of {} instead of []).
Paste the following on the browser console:
```
const envInfoAbility = await wp.abilities.getAbility(
	'core/get-environment-info'
);
const envInfoResult = await wp.abilities.executeAbility(
	'core/get-environment-info'
);
await wp.abilities.registerAbility( {
	...envInfoAbility,
	name: 'core/get-environment-info-client',
	callback: () => envInfoResult,
} );


const siteInfoAbility = await wp.abilities.getAbility(
	'core/get-site-info'
);
const siteInfoResult = await wp.abilities.executeAbility(
	'core/get-site-info'
);
await wp.abilities.registerAbility( {
	...siteInfoAbility,
	name: 'core/get-site-info-cli',
	callback: () => siteInfoResult,
} );
[await wp.abilities.executeAbility( 'core/get-site-info-cli' ), await wp.abilities.executeAbility( 'core/get-environment-info-client' ) ]
```

Verify both abilities execute with success.