### PR TITLE
Update version to 0.5.0 in preparation to Composer package release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,10 @@
 # Files and directories to exclude from the generated archive (export-ignore).
 # These will be omitted from GitHub/Packagist ZIP archives to keep packages small.
 
+/packages/client/src/ export-ignore
+/packages/client/.* export-ignore
+/packages/client/*.* export-ignore
+
 # Tests and test fixtures
 /tests/ export-ignore
 

--- a/abilities-api.php
+++ b/abilities-api.php
@@ -12,7 +12,7 @@
  * Plugin URI:        https://github.com/WordPress/abilities-api
  * Description:       Provides a framework for registering and executing AI abilities in WordPress.
  * Requires at least: 6.8
- * Version:           0.3.0
+ * Version:           0.5.0
  * Requires PHP:      7.2
  * Author:            WordPress.org Contributors
  * Author URI:        https://github.com/WordPress/abilities-api/graphs/contributors

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Version of the plugin.
 if ( ! defined( 'WP_ABILITIES_API_VERSION' ) ) {
-	define( 'WP_ABILITIES_API_VERSION', '0.3.0' );
+	define( 'WP_ABILITIES_API_VERSION', '0.5.0' );
 }
 
 // Load core classes if they are not already defined (for non-Composer installs or direct includes).


### PR DESCRIPTION
Cherry picking e90c0c256ee046b21e79fda894990716d001e44f from `release/0.5` branch that bumps the version number and adjusts `.gitattributes` settings.