### PR TITLE
Docs: Add missing @return tags and improve return value descriptions

### DIFF
--- a/includes/abilities-api/class-wp-ability-category.php
+++ b/includes/abilities-api/class-wp-ability-category.php
@@ -2,7 +2,8 @@
 /**
  * Abilities API
  *
- * Defines WP_Ability_Category class.
+ * Defines the WP_Ability_Category class for organizing and categorizing
+ * related abilities within the Abilities API.
  *
  * @package WordPress
  * @subpackage Abilities API
@@ -186,7 +187,7 @@ final class WP_Ability_Category {
 	 *
 	 * @since 6.9.0
 	 *
-	 * @return array<string,mixed> The metadata for the ability category.
+	 * @return array<string, mixed> The metadata for the ability category.
 	 */
 	public function get_meta(): array {
 		return $this->meta;

--- a/includes/rest-api/class-wp-rest-abilities-init.php
+++ b/includes/rest-api/class-wp-rest-abilities-init.php
@@ -23,6 +23,7 @@ class WP_REST_Abilities_Init {
 	 *
 	 * @param WP_REST_Server|null $rest_server Optional. The REST server to register routes with. Default null, which
 	 *                                         will use the main REST server instance.
+	 * @return void
 	 */
 	public static function register_routes( $rest_server = null ): void {
 		if ( ! $rest_server instanceof WP_REST_Server ) {

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-v1-categories-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-v1-categories-controller.php
@@ -40,6 +40,7 @@ class WP_REST_Abilities_V1_Categories_Controller extends WP_REST_Controller {
 	 * @since 6.9.0
 	 *
 	 * @see register_rest_route()
+	 * @return void
 	 */
 	public function register_routes(): void {
 		register_rest_route(
@@ -161,7 +162,7 @@ class WP_REST_Abilities_V1_Categories_Controller extends WP_REST_Controller {
 	 * @since 6.9.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
-	 * @return bool True if the request has read access.
+	 * @return bool True if the request has read access, false otherwise.
 	 */
 	public function get_items_permissions_check( $request ) {
 		return current_user_can( 'read' );
@@ -173,7 +174,7 @@ class WP_REST_Abilities_V1_Categories_Controller extends WP_REST_Controller {
 	 * @since 6.9.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
-	 * @return bool True if the request has read access.
+	 * @return bool True if the request has read access, false otherwise.
 	 */
 	public function get_item_permissions_check( $request ) {
 		return current_user_can( 'read' );

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -40,6 +40,7 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 	 * @since 6.9.0
 	 *
 	 * @see register_rest_route()
+	 * @return void
 	 */
 	public function register_routes(): void {
 		register_rest_route(
@@ -176,7 +177,7 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 	 * @since 6.9.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
-	 * @return bool True if the request has read access.
+	 * @return bool True if the request has read access, false otherwise.
 	 */
 	public function get_items_permissions_check( $request ) {
 		return current_user_can( 'read' );
@@ -188,7 +189,7 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 	 * @since 6.9.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
-	 * @return bool True if the request has read access.
+	 * @return bool True if the request has read access, false otherwise.
 	 */
 	public function get_item_permissions_check( $request ) {
 		return current_user_can( 'read' );

--- a/includes/rest-api/endpoints/class-wp-rest-abilities-v1-run-controller.php
+++ b/includes/rest-api/endpoints/class-wp-rest-abilities-v1-run-controller.php
@@ -40,6 +40,7 @@ class WP_REST_Abilities_V1_Run_Controller extends WP_REST_Controller {
 	 * @since 6.9.0
 	 *
 	 * @see register_rest_route()
+	 * @return void
 	 */
 	public function register_routes(): void {
 		register_rest_route(
@@ -188,7 +189,7 @@ class WP_REST_Abilities_V1_Run_Controller extends WP_REST_Controller {
 	 * @since 6.9.0
 	 *
 	 * @param WP_REST_Request $request The request object.
-	 * @return mixed|null The input parameters.
+	 * @return mixed|null The input parameters, or null if not provided.
 	 */
 	private function get_input_from_request( $request ) {
 		if ( in_array( $request->get_method(), array( 'GET', 'DELETE' ), true ) ) {


### PR DESCRIPTION
## Summary

Improves inline documentation compliance with [WordPress Inline Documentation Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/) by adding missing `@return` tags and enhancing return value descriptions.

## Changes

### ✅ Added @return void tags (4 methods)
- `WP_REST_Abilities_Init::register_routes()`
- `WP_REST_Abilities_V1_List_Controller::register_routes()`
- `WP_REST_Abilities_V1_Categories_Controller::register_routes()`
- `WP_REST_Abilities_V1_Run_Controller::register_routes()`

### ✅ Enhanced boolean return descriptions (4 methods)
**Before:** `@return bool True if the request has read access.`  
**After:** `@return bool True if the request has read access, false otherwise.`

Covers both true and false cases for all permission check methods.

### ✅ Clarified mixed return type (1 method)
**Before:** `@return mixed|null The input parameters.`  
**After:** `@return mixed|null The input parameters, or null if not provided.`

### ✅ Fixed type hint spacing (1 location)
**Before:** `array<string,mixed>`  
**After:** `array<string, mixed>`

### ✅ Enhanced file description (1 file)
Added more detailed description to `class-wp-ability-category.php` header.

## Impact

- ✅ Complies with WordPress documentation standards
- ✅ Improves IDE autocomplete and static analysis
- ✅ Makes return values clearer for developers
- ✅ Documentation-only changes (no functional changes)

