### PR TITLE
Make example workable

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,12 +110,7 @@ function my_plugin_register_abilities() {
     wp_register_ability( 'my-plugin/get-site-title', array(
         'label'               => __( 'Get Site Title', 'my-plugin' ),
         'description'         => __( 'Retrieves the title of the current WordPress site.', 'my-plugin' ),
-        'category'            => 'site-info',
-        'input_schema'        => array(
-            'type'                 => 'object',
-            'properties'           => array(),
-            'additionalProperties' => false,
-        ),
+        'category'            => 'site',
         'output_schema'       => array(
             'type'        => 'string',
             'description' => 'The site title.',


### PR DESCRIPTION
Two small changes to the Getting Started example to make sure it works out of the box.

As of now, if you copy and paste the example you get 2 errrors:

1. You are prompted to register the abilities category first
2. when you call `execute()` you get an error because it's expecting an input.

Not sure if that was intentional, but I do think it's valuable to have an example that just works in this section.