### PR TITLE
Fix incomplete translator comments in WP_Ability and WP_Ability_Category

### DIFF
--- a/includes/abilities-api/class-wp-ability-category.php
+++ b/includes/abilities-api/class-wp-ability-category.php
@@ -88,7 +88,7 @@ final class WP_Ability_Category {
 				_doing_it_wrong(
 					__METHOD__,
 					sprintf(
-						/* translators: %s: Property name. */
+						/* translators: %1$s: Property name, %2$s: Ability category slug, %3$s: Class name. */
 						__( 'Property "%1$s" is not a valid property for ability category "%2$s". Please check the %3$s class for allowed properties.' ),
 						'<code>' . esc_html( $property_name ) . '</code>',
 						'<code>' . esc_html( $this->slug ) . '</code>',

--- a/includes/abilities-api/class-wp-ability.php
+++ b/includes/abilities-api/class-wp-ability.php
@@ -174,7 +174,7 @@ class WP_Ability {
 				_doing_it_wrong(
 					__METHOD__,
 					sprintf(
-						/* translators: %s: Property name. */
+						/* translators: %1$s: Property name, %2$s: Ability name, %3$s: Class name. */
 						__( 'Property "%1$s" is not a valid property for ability "%2$s". Please check the %3$s class for allowed properties.' ),
 						'<code>' . esc_html( $property_name ) . '</code>',
 						'<code>' . esc_html( $this->name ) . '</code>',


### PR DESCRIPTION
The translator comments in `WP_Ability` and `WP_Ability_Category` only describe the first placeholder but the strings have three.

### WP_Ability (`class-wp-ability.php`)

Before:
```php
/* translators: %s: Property name. */
```

After:
```php
/* translators: %1$s: Property name, %2$s: Ability name, %3$s: Class name. */
```

### WP_Ability_Category (`class-wp-ability-category.php`)

Before:
```php
/* translators: %s: Property name. */
```

After:
```php
/* translators: %1$s: Property name, %2$s: Ability category slug, %3$s: Class name. */
```

Translators using tools like translate.wordpress.org don't see the source code, so having all placeholders described helps them know what each one is.